### PR TITLE
chore: disable angular analytics

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -105,5 +105,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }


### PR DESCRIPTION
The CLI keeps asking about sharing data, and when I say no, it adds this. Is it's right to commit it and does everyone want it disabled? I couldn't get it to disable globally...