### PR TITLE
Sof 1593/change unsubscribe lambdas to subscription objects

### DIFF
--- a/src/app/core/services/basic-rundown-state.service.ts
+++ b/src/app/core/services/basic-rundown-state.service.ts
@@ -68,7 +68,7 @@ export class BasicRundownStateService implements OnDestroy {
   private deactivateBasicRundownFromEvent(event: RundownEvent): void {
     this.basicRundowns = this.basicRundowns.map(basicRundown => {
       if (basicRundown.id === event.rundownId) {
-        basicRundown.isActive = true
+        basicRundown.isActive = false
       }
       return basicRundown
     })

--- a/src/app/core/services/basic-rundown-state.service.ts
+++ b/src/app/core/services/basic-rundown-state.service.ts
@@ -19,20 +19,20 @@ export class BasicRundownStateService implements OnDestroy {
       private readonly connectionStatusObserver: ConnectionStatusObserver
   ) {
     this.basicRundownsSubject = new BehaviorSubject<BasicRundown[]>(this.basicRundowns)
-    this.registerEventConsumers()
+    this.subscribeToEvents()
     this.resetBasicRundownSubject()
   }
 
-  private registerEventConsumers(): void {
-    const unsubscribeFromConnectionStatusEvents = this.registerConnectionStatusConsumers()
-    const unsubscribesFromRundownEvents = this.registerBasicRundownEventConsumers()
+  private subscribeToEvents(): void {
+    const connectionStatusSubscriptions = this.subscribeToConnectionStatus()
+    const rundownEventSubscriptions = this.subscribeToRundownEvents()
     this.eventSubscriptions = [
-        ...unsubscribesFromRundownEvents,
-        ...unsubscribeFromConnectionStatusEvents
+        ...rundownEventSubscriptions,
+        ...connectionStatusSubscriptions
       ]
   }
 
-  private registerConnectionStatusConsumers(): EventSubscription[] {
+  private subscribeToConnectionStatus(): EventSubscription[] {
     return [
       this.connectionStatusObserver.subscribeToReconnect(this.resetBasicRundownSubject.bind(this))
     ]
@@ -45,7 +45,7 @@ export class BasicRundownStateService implements OnDestroy {
         .catch(error => console.error('[error]', 'Encountered error while fetching basic rundowns:', error))
   }
 
-  private registerBasicRundownEventConsumers(): EventSubscription[] {
+  private subscribeToRundownEvents(): EventSubscription[] {
     return [
       this.rundownEventObserver.subscribeToRundownActivation(this.activateBasicRundownFromEvent.bind(this)),
       this.rundownEventObserver.subscribeToRundownDeactivation(this.deactivateBasicRundownFromEvent.bind(this)),

--- a/src/app/core/services/connection-status-observer.service.ts
+++ b/src/app/core/services/connection-status-observer.service.ts
@@ -26,6 +26,6 @@ export class ConnectionStatusObserver implements OnDestroy {
     }
 
     public ngOnDestroy() {
-        this.closedEventSubscription.unsubscribe
+        this.closedEventSubscription.unsubscribe()
     }
 }

--- a/src/app/core/services/connection-status-observer.service.ts
+++ b/src/app/core/services/connection-status-observer.service.ts
@@ -1,4 +1,4 @@
-import { EventObserver, Unsubscribe } from '../../event-system/abstractions/event-observer.service'
+import { EventObserver, EventSubscription } from '../../event-system/abstractions/event-observer.service'
 import { Injectable, OnDestroy } from '@angular/core'
 
 enum ConnectionEventType {
@@ -8,14 +8,14 @@ enum ConnectionEventType {
 
 @Injectable()
 export class ConnectionStatusObserver implements OnDestroy {
-    private readonly unsubscribeFromClosedEvent: Unsubscribe
+    private readonly closedEventSubscription: EventSubscription
     private hasHadOpenConnection: boolean = false
 
     constructor(private readonly eventObserver: EventObserver) {
-        this.unsubscribeFromClosedEvent = eventObserver.subscribe(ConnectionEventType.CLOSED, () => this.hasHadOpenConnection = true)
+        this.closedEventSubscription = eventObserver.subscribe(ConnectionEventType.CLOSED, () => this.hasHadOpenConnection = true)
     }
 
-    public subscribeToReconnect(consumer: () => void): Unsubscribe {
+    public subscribeToReconnect(consumer: () => void): EventSubscription {
         return this.eventObserver.subscribe(ConnectionEventType.OPENED, () => {
             if (!this.hasHadOpenConnection) {
                 this.hasHadOpenConnection = true
@@ -26,6 +26,6 @@ export class ConnectionStatusObserver implements OnDestroy {
     }
 
     public ngOnDestroy() {
-        this.unsubscribeFromClosedEvent()
+        this.closedEventSubscription.unsubscribe
     }
 }

--- a/src/app/core/services/http-basic-rundown.service.ts
+++ b/src/app/core/services/http-basic-rundown.service.ts
@@ -21,7 +21,7 @@ export class HttpBasicRundownService implements BasicRundownService {
     return this.http.get<unknown>(`${RUNDOWN_URL}/basic`)
       .pipe(
         catchError((error) => this.httpErrorService.catchError(error)),
-        map(this.entityParser.parseBasicRundowns) // TODO: Catch this and display/log it
+        map(this.entityParser.parseBasicRundowns.bind(this.entityParser)) // TODO: Catch this and display/log it
       )
   }
 }

--- a/src/app/core/services/http-rundown.service.ts
+++ b/src/app/core/services/http-rundown.service.ts
@@ -20,7 +20,7 @@ export class HttpRundownService implements RundownService {
   public fetchRundown(rundownId: string): Observable<Rundown> {
     return this.http.get<unknown>(`${RUNDOWN_URL}/${rundownId}`).pipe(
       catchError((error) => this.httpErrorService.catchError(error)),
-      map(this.entityParser.parseRundown)
+      map(this.entityParser.parseRundown.bind(this.entityParser))
     )
   }
 

--- a/src/app/core/services/rundown-event-observer.service.ts
+++ b/src/app/core/services/rundown-event-observer.service.ts
@@ -16,56 +16,56 @@ export class RundownEventObserver {
     public subscribeToRundownActivation(consumer: (event: RundownActivatedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.ACTIVATED,
-            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseActivatedEvent)
+            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseActivatedEvent.bind(this.rundownEventParser))
         )
     }
 
     public subscribeToRundownDeactivation(consumer: (event: RundownDeactivatedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.DEACTIVATED,
-            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseDeactivatedEvent)
+            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseDeactivatedEvent.bind(this.rundownEventParser))
         )
     }
 
     public subscribeToRundownDeletion(consumer: (event: RundownDeletedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.DELETED,
-            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseDeletedEvent)
+            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseDeletedEvent.bind(this.rundownEventParser))
         )
     }
 
     public subscribeToRundownReset(consumer: (event: RundownResetEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.RESET,
-            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseResetEvent)
+            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseResetEvent.bind(this.rundownEventParser))
         )
     }
 
     public subscribeToRundownTake(consumer: (event: PartTakenEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.TAKEN,
-            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseTakenEvent)
+            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseTakenEvent.bind(this.rundownEventParser))
         )
     }
 
     public subscribeToRundownSetNext(consumer: (event: PartSetAsNextEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.SET_NEXT,
-            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseSetNextEvent)
+            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseSetNextEvent.bind(this.rundownEventParser))
         )
     }
 
     public subscribeToRundownAdLibPieceInserted(consumer: (event: RundownAdLibPieceInsertedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.AD_LIB_PIECE_INSERTED,
-            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseAdLibPieceInserted)
+            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseAdLibPieceInserted.bind(this.rundownEventParser))
         )
     }
 
     public subscribeToRundownInfinitePieceAdded(consumer: (event: RundownInfinitePieceAddedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.INFINITE_PIECE_ADDED,
-            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseInfinitePieceAdded)
+            this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseInfinitePieceAdded.bind(this.rundownEventParser))
         )
     }
 

--- a/src/app/core/services/rundown-event-observer.service.ts
+++ b/src/app/core/services/rundown-event-observer.service.ts
@@ -1,4 +1,4 @@
-import { EventConsumer, EventObserver, TypedEvent, Unsubscribe } from '../../event-system/abstractions/event-observer.service'
+import { EventConsumer, EventObserver, TypedEvent, EventSubscription } from '../../event-system/abstractions/event-observer.service'
 import { Injectable } from '@angular/core'
 import { RundownEventParser } from '../abstractions/rundown-event.parser'
 import { RundownEventType } from '../models/rundown-event-type'
@@ -13,56 +13,56 @@ import {
 export class RundownEventObserver {
     constructor(private readonly eventObserver: EventObserver, private readonly rundownEventParser: RundownEventParser) {}
 
-    public subscribeToRundownActivation(consumer: (event: RundownActivatedEvent) => void): Unsubscribe {
+    public subscribeToRundownActivation(consumer: (event: RundownActivatedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.ACTIVATED,
             this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseActivatedEvent)
         )
     }
 
-    public subscribeToRundownDeactivation(consumer: (event: RundownDeactivatedEvent) => void): Unsubscribe {
+    public subscribeToRundownDeactivation(consumer: (event: RundownDeactivatedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.DEACTIVATED,
             this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseDeactivatedEvent)
         )
     }
 
-    public subscribeToRundownDeletion(consumer: (event: RundownDeletedEvent) => void): Unsubscribe {
+    public subscribeToRundownDeletion(consumer: (event: RundownDeletedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.DELETED,
             this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseDeletedEvent)
         )
     }
 
-    public subscribeToRundownReset(consumer: (event: RundownResetEvent) => void): Unsubscribe {
+    public subscribeToRundownReset(consumer: (event: RundownResetEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.RESET,
             this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseResetEvent)
         )
     }
 
-    public subscribeToRundownTake(consumer: (event: PartTakenEvent) => void): Unsubscribe {
+    public subscribeToRundownTake(consumer: (event: PartTakenEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.TAKEN,
             this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseTakenEvent)
         )
     }
 
-    public subscribeToRundownSetNext(consumer: (event: PartSetAsNextEvent) => void): Unsubscribe {
+    public subscribeToRundownSetNext(consumer: (event: PartSetAsNextEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.SET_NEXT,
             this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseSetNextEvent)
         )
     }
 
-    public subscribeToRundownAdLibPieceInserted(consumer: (event: RundownAdLibPieceInsertedEvent) => void): Unsubscribe {
+    public subscribeToRundownAdLibPieceInserted(consumer: (event: RundownAdLibPieceInsertedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.AD_LIB_PIECE_INSERTED,
             this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseAdLibPieceInserted)
         )
     }
 
-    public subscribeToRundownInfinitePieceAdded(consumer: (event: RundownInfinitePieceAddedEvent) => void): Unsubscribe {
+    public subscribeToRundownInfinitePieceAdded(consumer: (event: RundownInfinitePieceAddedEvent) => void): EventSubscription {
         return this.eventObserver.subscribe(
             RundownEventType.INFINITE_PIECE_ADDED,
             this.createEventValidatingConsumer(consumer, this.rundownEventParser.parseInfinitePieceAdded)

--- a/src/app/core/services/rundown-state.service.ts
+++ b/src/app/core/services/rundown-state.service.ts
@@ -25,19 +25,19 @@ export class RundownStateService implements OnDestroy {
       private readonly rundownEventObserver: RundownEventObserver,
       private readonly connectionStatusObserver: ConnectionStatusObserver
   ) {
-    this.registerEventConsumers()
+    this.subscribeToEvents()
   }
 
-  private registerEventConsumers(): void {
-    const unsubscribeFromConnectionStatusEvents = this.registerConnectionStatusConsumers()
-    const unsubscribesFromRundownEvents = this.registerRundownEventConsumers()
+  private subscribeToEvents(): void {
+    const connectionStatusSubscriptions = this.subscribeToConnectionStatus()
+    const rundownEventSubscriptions = this.subscribeToRundownEvents()
     this.eventSubscriptions = [
-        ...unsubscribesFromRundownEvents,
-        ...unsubscribeFromConnectionStatusEvents
+        ...rundownEventSubscriptions,
+        ...connectionStatusSubscriptions
       ]
   }
 
-  private registerConnectionStatusConsumers(): EventSubscription[] {
+  private subscribeToConnectionStatus(): EventSubscription[] {
     return [
       this.connectionStatusObserver.subscribeToReconnect(this.resetRundownSubjects.bind(this))
     ]
@@ -56,7 +56,7 @@ export class RundownStateService implements OnDestroy {
         .catch(error => console.error('[error]', `Encountered error while fetching rundown with id '${rundownId}':`, error))
   }
 
-  private registerRundownEventConsumers(): EventSubscription[] {
+  private subscribeToRundownEvents(): EventSubscription[] {
     return [
       this.rundownEventObserver.subscribeToRundownActivation(this.activateRundownFromEvent.bind(this)),
       this.rundownEventObserver.subscribeToRundownDeactivation(this.deactivateRundownFromEvent.bind(this)),

--- a/src/app/event-system/abstractions/event-observer.service.ts
+++ b/src/app/event-system/abstractions/event-observer.service.ts
@@ -2,8 +2,10 @@ export interface TypedEvent {
     type: string
 }
 export type EventConsumer = (event: TypedEvent) => void
-export type Unsubscribe = () => void
+export interface EventSubscription {
+    unsubscribe: () => void
+}
 
 export abstract class EventObserver {
-    public abstract subscribe(subject: string, consumer: EventConsumer): Unsubscribe
+    public abstract subscribe(subject: string, consumer: EventConsumer): EventSubscription
 }

--- a/src/app/event-system/services/websocket-event-observer.service.ts
+++ b/src/app/event-system/services/websocket-event-observer.service.ts
@@ -1,4 +1,4 @@
-import { EventConsumer, EventObserver, TypedEvent, Unsubscribe } from '../abstractions/event-observer.service'
+import { EventConsumer, EventObserver, TypedEvent, EventSubscription } from '../abstractions/event-observer.service'
 import { RobustWebSocket } from './robust-websocket.service'
 import { Injectable } from '@angular/core'
 import { RobustWebSocketFactory } from '../factories/robust-websocket.factory'
@@ -63,7 +63,7 @@ export class WebSocketEventObserver implements EventObserver {
         this.publishEvent(event)
     }
 
-    public subscribe(subject: string, consumer: EventConsumer): Unsubscribe {
+    public subscribe(subject: string, consumer: EventConsumer): EventSubscription {
         this.ensureSubject(subject)
         this.subscriptions[subject].add(consumer)
         return () => this.unsubscribe(subject, consumer)

--- a/src/app/event-system/services/websocket-event-observer.service.ts
+++ b/src/app/event-system/services/websocket-event-observer.service.ts
@@ -1,7 +1,7 @@
-import { EventConsumer, EventObserver, TypedEvent, Unsubscribe } from './event-observer.service'
+import { EventConsumer, EventObserver, TypedEvent, Unsubscribe } from '../abstractions/event-observer.service'
 import { RobustWebSocket } from './robust-websocket.service'
 import { Injectable } from '@angular/core'
-import { RobustWebSocketFactory } from './robust-websocket.factory'
+import { RobustWebSocketFactory } from '../factories/robust-websocket.factory'
 
 @Injectable()
 export class WebSocketEventObserver implements EventObserver {


### PR DESCRIPTION
- Converts `Unsubscribe` lambda to `EventSubscription` object.
- Corrects context binding for parser method usage.
- Corrected handling of deactivation of rundown in BasicRundownStateService.