### PR TITLE
Display message if no rundowns are available or if they are loading

### DIFF
--- a/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.html
+++ b/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.html
@@ -1,6 +1,15 @@
-<h1 class="c-rundown-overview-title">Rundowns</h1>
-<table mat-table [dataSource]="basicRundowns">
+<h1 class="c-rundown-overview__title">Rundowns</h1>
 
+<mat-card class="c-rundown-overview__loading-rundowns" *ngIf="isLoading">
+  <mat-card-title>Loading rundowns...</mat-card-title>
+</mat-card>
+
+<mat-card class="c-rundown-overview__no-rundowns" *ngIf="!isLoading && basicRundowns.length === 0">
+  <mat-card-title>There are currently no rundowns available.</mat-card-title>
+  <mat-card-content>Check your connection and if you have configured the Ingest Gateway.</mat-card-content>
+</mat-card>
+
+<table mat-table [dataSource]="basicRundowns" *ngIf="!isLoading && basicRundowns.length > 0">
   <ng-container matColumnDef="status">
     <mat-header-cell *matHeaderCellDef></mat-header-cell>
     <mat-cell *matCellDef="let basicRundown" >

--- a/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.html
+++ b/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.html
@@ -1,13 +1,13 @@
 <h1 class="c-rundown-overview__title">Rundowns</h1>
 
-<mat-card class="c-rundown-overview__loading-rundowns" *ngIf="isLoading">
+<div class="c-rundown-overview__loading-rundowns" *ngIf="isLoading">
   <mat-card-title>Loading rundowns...</mat-card-title>
-</mat-card>
+</div>
 
-<mat-card class="c-rundown-overview__no-rundowns" *ngIf="!isLoading && basicRundowns.length === 0">
-  <mat-card-title>There are currently no rundowns available.</mat-card-title>
-  <mat-card-content>Check your connection and if you have configured the Ingest Gateway.</mat-card-content>
-</mat-card>
+<div class="c-rundown-overview__no-rundowns" *ngIf="!isLoading && basicRundowns.length === 0">
+  <h2>There are currently no rundowns available.</h2>
+  <p>Check your connection and if you have configured the Ingest Gateway.</p>
+</div>
 
 <table mat-table [dataSource]="basicRundowns" *ngIf="!isLoading && basicRundowns.length > 0">
   <ng-container matColumnDef="status">
@@ -18,7 +18,7 @@
   </ng-container>
 
   <ng-container matColumnDef="name">
-    <mat-header-cell *matHeaderCellDef> Rundown </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef>Rundown</mat-header-cell>
     <mat-cell *matCellDef="let basicRundown" class="c-rundown-name" (click)="navigateToRundown(basicRundown)">
       {{basicRundown.name}}
     </mat-cell>

--- a/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.scss
+++ b/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.scss
@@ -42,7 +42,7 @@
   }
 }
 
-.c-rundown-overview-title {
+.c-rundown-overview__title {
   margin: 1em;
   font-size: 3em;
   font-weight: lighter;

--- a/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.scss
+++ b/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.scss
@@ -42,6 +42,13 @@
   }
 }
 
+.c-rundown-overview {
+  &__no-rundowns,
+  &__loading-rundowns {
+    text-align: center;
+  }
+}
+
 .c-rundown-overview__title {
   margin: 1em;
   font-size: 3em;

--- a/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.ts
+++ b/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core'
+import { Component, OnDestroy, OnInit } from '@angular/core'
 import { Router } from '@angular/router'
 import { Paths } from '../../../app-routing.module'
 import { BasicRundown } from "../../../core/models/basic-rundown";
@@ -7,15 +7,17 @@ import { Rundown } from '../../../core/models/rundown';
 import { DialogService } from '../../../shared/services/dialog.service';
 import { Color } from "../../../shared/enums/color";
 import { BasicRundownStateService } from '../../../core/services/basic-rundown-state.service'
+import { SubscriptionLike } from 'rxjs'
 
 @Component({
   selector: 'sofie-rundown-overview',
   templateUrl: './rundown-overview.component.html',
   styleUrls: ['./rundown-overview.component.scss']
 })
-export class RundownOverviewComponent implements OnInit {
-
-  public basicRundowns: BasicRundown[]
+export class RundownOverviewComponent implements OnInit, OnDestroy {
+  public basicRundowns: BasicRundown[] = []
+  public isLoading: boolean = true
+  private subscriptions: SubscriptionLike[] = []
 
   constructor(
     private readonly router: Router,
@@ -25,10 +27,12 @@ export class RundownOverviewComponent implements OnInit {
   ) {}
 
   public ngOnInit(): void {
-    this.basicRundownStateService.subscribeToBasicRundowns(basicRundowns => {
+    const basicRundownSubscription: SubscriptionLike = this.basicRundownStateService.subscribeToBasicRundowns(basicRundowns => {
       console.log('[debug]: Updates basicRundowns for rundown overview', basicRundowns)
       this.basicRundowns = basicRundowns
     })
+    const isLoadingSubscription: SubscriptionLike = this.basicRundownStateService.subscribeToLoading(isLoading => this.isLoading = isLoading)
+    this.subscriptions = [basicRundownSubscription, isLoadingSubscription]
   }
 
   public navigateToRundown(basicRundown: BasicRundown): void {
@@ -41,6 +45,10 @@ export class RundownOverviewComponent implements OnInit {
 
   private deleteRundown(rundownId: string): void {
     this.rundownService.delete(rundownId).subscribe()
+  }
+
+  public ngOnDestroy(): void {
+    this.subscriptions.forEach(subscription => subscription.unsubscribe())
   }
 
   public readonly Color = Color;

--- a/src/app/rundown-overview/rundown-overview.module.ts
+++ b/src/app/rundown-overview/rundown-overview.module.ts
@@ -4,17 +4,19 @@ import {RundownOverviewComponent} from './components/rundown-overview/rundown-ov
 import {RundownOverviewRoutingModule} from './rundown-overview-routing.module';
 import {MatTableModule} from "@angular/material/table";
 import { PulsatingDotComponent } from './components/pulsating-dot/pulsating-dot.component';
+import { MatCardModule } from '@angular/material/card';
 
 
 @NgModule({
   declarations: [
     RundownOverviewComponent,
-    PulsatingDotComponent
+    PulsatingDotComponent,
   ],
-  imports: [
-    RundownOverviewRoutingModule,
-    SharedModule,
-    MatTableModule
-  ]
+    imports: [
+        RundownOverviewRoutingModule,
+        SharedModule,
+        MatTableModule,
+        MatCardModule
+    ]
 })
 export class RundownOverviewModule { }


### PR DESCRIPTION
The Rundown Overview component now displays a message indicating that no rundowns are available – if it us unable to retrieve rundowns or if there simply are none.
It also listens for when the BasicRundownStateService is loading/fetching data from remote in order to keep the user informed.

The styling basically a centered heading and a description for both scenarios.