### PR TITLE
Sof 1552/rename Server PieceType

### DIFF
--- a/src/app/core/enums/piece-type.ts
+++ b/src/app/core/enums/piece-type.ts
@@ -3,7 +3,7 @@ export enum PieceType {
   CAMERA = 'CAMERA',
   LIVE = 'LIVE',
   GRAPHIC = 'GRAPHIC',
-  SERVER = 'SERVER',
+  VIDEO_CLIP = 'VIDEO_CLIP',
   AUDIO = 'AUDIO',
   TRANSITION = 'TRANSITION',
 }


### PR DESCRIPTION
Dependentant on: https://github.com/tv2/sofie-server/pull/31

In https://github.com/tv2/sofie-server/pull/31 `PieceType.SERVER` was renamed to `PieceType.VIDEO_CLIP`. 
This is to reflect that change in the frontend.