### PR TITLE
Remote segment countdown rounds up to nearest second.

### DIFF
--- a/src/app/rundown-view/components/segment/segment.component.html
+++ b/src/app/rundown-view/components/segment/segment.component.html
@@ -9,8 +9,8 @@
       <span class="segment-expected-duration">{{(!segment.isUntimed ? expectedDurationInMs : 0) | timer: 'HH?:mm:ss' }}</span>
       <span class="segment-countdown">
         <sofie-countdown-label
-          *ngIf="hasRemotePiece && durationInMsUntilSegmentIsPutOnAir !== undefined"
-          [durationInMs]="durationInMsUntilSegmentIsPutOnAir"
+          *ngIf="hasRemotePiece && roundedDurationInMsUntilSegmentIsPutOnAir !== undefined"
+          [durationInMs]="roundedDurationInMsUntilSegmentIsPutOnAir"
           [currentEpochTime]="currentEpochTime"
         ></sofie-countdown-label>
       </span>

--- a/src/app/rundown-view/components/segment/segment.component.ts
+++ b/src/app/rundown-view/components/segment/segment.component.ts
@@ -40,6 +40,7 @@ export class SegmentComponent implements OnChanges, OnDestroy {
   public outputLayers: Tv2OutputLayer[] = []
 
   public expectedDurationInMs: number = 0
+  public roundedDurationInMsUntilSegmentIsPutOnAir?: number
 
   public pixelsPerSecond: number = INITIAL_PIXELS_PER_SECOND
   public get isAtMinimumZoomLevel(): boolean {
@@ -78,6 +79,10 @@ export class SegmentComponent implements OnChanges, OnDestroy {
       this.hasRemotePiece = this.segment.parts.some(part => this.hasPartRemotePiece(part))
       this.expectedDurationInMs =
         this.segment.expectedDurationInMs ?? this.segment.parts.reduce((sumOfExpectedDurationsInMsForParts, part) => sumOfExpectedDurationsInMsForParts + (part.expectedDuration ?? 0), 0)
+    }
+
+    if ('durationInMsUntilSegmentIsPutOnAir' in changes) {
+      this.roundedDurationInMsUntilSegmentIsPutOnAir = this.durationInMsUntilSegmentIsPutOnAir !== undefined ? 1000 * Math.ceil(this.durationInMsUntilSegmentIsPutOnAir / 1000) : undefined
     }
   }
 


### PR DESCRIPTION
The remote segment countdown works with positive numbers for the remaining duration, where other remaining durations use negative numbers. This causes an inconsistency, where the countdown is off by one second compared to the other timers, when formatted as seconds. To combat this, the remote segment countdown is rounded up to nearest second before being formatted.