### PR TITLE
ci: Adds simple 'Publish Image' workflow.

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,35 @@
+name: 'Publish Image'
+
+env:
+  node-version: 18
+  node-package-manager: yarn
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionTag:
+        description: 'Version tag (e.g. 46.3.1-staging)'
+        required: true
+        type: 'string'
+
+jobs:
+  publish-image-to-docker-hub:
+    name: 'Publish image to Docker Hub'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Retrieve repository files'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Log in to Docker Hub'
+        uses: 'docker/login-action@v3'
+        with:
+          username: '${{ secrets.DOCKERHUB_USERNAME }}'
+          password: '${{ secrets.DOCKERHUB_PASSWORD }}'
+
+      - name: 'Build and publish Docker image'
+        uses: 'docker/build-push-action@v5'
+        with:
+          context: '.'
+          push: true
+          tags: |
+            'tv2media/sofie-web-client:${{ inputs.versionTag }}'


### PR DESCRIPTION
Adds GitHub Action workflow for publishing a new Docker image to Docker Hub with `workflow_dispatch` as the trigger.
For the workflow dispatch information, the branch to publish from should be selected along with the version tag to use.

The version tag should be written as a semantic version (e.g.`46.3.1` or `46.3.1-staging`).