### PR TITLE
SOF-1724: Move simple publish image workflow to develop

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -32,4 +32,4 @@ jobs:
           context: '.'
           push: true
           tags: |
-            'tv2media/sofie-web-client:${{ inputs.versionTag }}'
+            tv2media/sofie-web-client:${{ inputs.versionTag }}

--- a/angular.json
+++ b/angular.json
@@ -11,6 +11,7 @@
             "translation": "src/locale/messages.da.xlf"
           },
           "en-US": {
+            "baseHref": "",
             "translation": "src/locale/messages.en-US.xlf"
           }
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,16 @@ server {
 
   root /usr/share/nginx/html;
 
-  location / {
+  location /da {
     try_files $uri $uri/ /index.html =404;
+  }
+
+  location ~ ^/en-US {
+    try_files $uri $uri/ /index.html =404;
+  }
+
+  location / {
+    root /usr/share/nginx/html/en-US;
+    try_files /en-US/$uri /en-US/$uri/ /en-US/index.html =404;
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,7 @@ server {
 
   root /usr/share/nginx/html;
 
-  location ~ ^/(en-US|da) {
+  location /da/ {
     try_files $uri $uri/ /index.html =404;
   }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,16 +14,12 @@ server {
 
   root /usr/share/nginx/html;
 
-  location /da {
-    try_files $uri $uri/ /index.html =404;
-  }
-
-  location ~ ^/en-US {
+  location ~ ^/(en-US|da) {
     try_files $uri $uri/ /index.html =404;
   }
 
   location / {
     root /usr/share/nginx/html/en-US;
-    try_files /en-US/$uri /en-US/$uri/ /en-US/index.html =404;
+    try_files $uri $uri/ /index.html =404;
   }
 }


### PR DESCRIPTION
Moving changes from #77 from master to develop.
In addition, there are some fixes for the Nginx configuration in regards to multi-locale support. The locale `en-US` is set as the default, when visiting a sofie installation.