### PR TITLE
SOF-1699 add empty router for setting pages with 2 new routes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ export enum Paths {
   HOME = '',
   RUNDOWNS = 'rundowns',
   STATUS = 'status',
+  SETTINGS = 'settings',
 }
 
 const routes: Routes = [
@@ -15,6 +16,10 @@ const routes: Routes = [
   {
     path: Paths.RUNDOWNS,
     loadChildren: () => import('./rundown-overview/rundown-overview.module').then(module => module.RundownOverviewModule),
+  },
+  {
+    path: Paths.SETTINGS,
+    loadChildren: () => import('./settings/settings.module').then(m => m.SettingsModule),
   },
   {
     path: `${Paths.RUNDOWNS}/:rundownId`,

--- a/src/app/settings/action-triggers/action-triggers.module.ts
+++ b/src/app/settings/action-triggers/action-triggers.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core'
+import { MatListModule } from '@angular/material/list'
+import { SharedModule } from 'src/app/shared/shared.module'
+import { ActionTriggersComponent } from './components/action-triggers/action-triggers.component'
+import { RouterModule, Routes } from '@angular/router'
+
+const routes: Routes = [{ path: '', component: ActionTriggersComponent }]
+
+@NgModule({
+  declarations: [ActionTriggersComponent],
+  imports: [SharedModule, MatListModule, RouterModule.forChild(routes)],
+})
+export class ActionTriggersModule {}

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.html
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.html
@@ -1,0 +1,3 @@
+<div class="c-action-triggers">
+  <h2>keyboard shortcuts</h2>
+</div>

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.spec.ts
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ActionTriggersComponent } from './action-triggers.component'
+
+describe('ActionTriggersComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<ActionTriggersComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [ActionTriggersComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<ActionTriggersComponent> = TestBed.createComponent(ActionTriggersComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.ts
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-action-triggers',
+  templateUrl: './action-triggers.component.html',
+  styleUrls: ['./action-triggers.component.scss'],
+})
+export class ActionTriggersComponent {}

--- a/src/app/settings/components/clear-cache/clear-cache.component.html
+++ b/src/app/settings/components/clear-cache/clear-cache.component.html
@@ -1,0 +1,1 @@
+Clear cache

--- a/src/app/settings/components/clear-cache/clear-cache.component.spec.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ClearCacheComponent } from './clear-cache.component'
+
+describe('ClearCacheComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<ClearCacheComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [ClearCacheComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<ClearCacheComponent> = TestBed.createComponent(ClearCacheComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/components/clear-cache/clear-cache.component.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-clear-cache',
+  templateUrl: './clear-cache.component.html',
+  styleUrls: ['./clear-cache.component.scss'],
+})
+export class ClearCacheComponent {}

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.html
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.html
@@ -1,0 +1,8 @@
+<mat-toolbar class="c-side-bar">
+  <mat-nav-list class="c-side-bar__nav-item">
+    <a routerLinkActive="active-tab" [routerLink]="['/settings/action-triggers']" i18n>settings.action-triggers.label</a>
+  </mat-nav-list>
+  <mat-nav-list class="c-side-bar__nav-item">
+    <a routerLinkActive="active-tab" [routerLink]="['/settings/clear-cache']" i18n>settings.clear-cache.label</a>
+  </mat-nav-list>
+</mat-toolbar>

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.scss
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.scss
@@ -1,0 +1,30 @@
+.c-side-bar {
+  --text-color: white;
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  height: auto;
+  background-color: transparent;
+  align-items: flex-start;
+  padding: 0;
+
+  &__nav-item {
+    font-weight: lighter;
+    width: 100%;
+    padding-top: 0;
+    a {
+      padding: 0.5rem 1em;
+      font-size: medium;
+      display: block;
+      &.active-tab {
+        background-color: #343434;
+        color: #5ebaf4;
+      }
+    }
+  }
+
+  &__nav-item:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.spec.ts
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { SettingsMenuComponent } from './settings-menu.component'
+
+describe('SettingsMenuComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<SettingsMenuComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [SettingsMenuComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<SettingsMenuComponent> = TestBed.createComponent(SettingsMenuComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.ts
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-settings-menu',
+  templateUrl: './settings-menu.component.html',
+  styleUrls: ['./settings-menu.component.scss'],
+})
+export class SettingsMenuComponent {}

--- a/src/app/settings/components/settings/settings.component.html
+++ b/src/app/settings/components/settings/settings.component.html
@@ -1,0 +1,6 @@
+<sofie-header></sofie-header>
+
+<mat-drawer-container class="c-settings">
+  <mat-drawer mode="side" opened><sofie-settings-menu></sofie-settings-menu></mat-drawer>
+  <mat-drawer-content><router-outlet></router-outlet></mat-drawer-content>
+</mat-drawer-container>

--- a/src/app/settings/components/settings/settings.component.scss
+++ b/src/app/settings/components/settings/settings.component.scss
@@ -1,0 +1,4 @@
+.c-settings {
+  min-height: calc(100vh - 70px);
+  border-top: 1px solid #fff;
+}

--- a/src/app/settings/components/settings/settings.component.spec.ts
+++ b/src/app/settings/components/settings/settings.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { SettingsComponent } from './settings.component'
+
+describe('SettingsComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<SettingsComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [SettingsComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<SettingsComponent> = TestBed.createComponent(SettingsComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/components/settings/settings.component.ts
+++ b/src/app/settings/components/settings/settings.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss'],
+})
+export class SettingsComponent {}

--- a/src/app/settings/settings-routing.module.ts
+++ b/src/app/settings/settings-routing.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core'
+import { RouterModule, Routes } from '@angular/router'
+import { SettingsComponent } from './components/settings/settings.component'
+import { ClearCacheComponent } from './components/clear-cache/clear-cache.component'
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SettingsComponent,
+    children: [
+      { path: '', redirectTo: 'action-triggers', pathMatch: 'full' },
+      { path: 'action-triggers', loadChildren: () => import('./action-triggers/action-triggers.module').then(module => module.ActionTriggersModule) },
+      { path: 'clear-cache', component: ClearCacheComponent },
+    ],
+  },
+]
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SettingsRoutingModule {}

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core'
+import { SharedModule } from '../shared/shared.module'
+import { SettingsRoutingModule } from './settings-routing.module'
+import { SettingsComponent } from './components/settings/settings.component'
+import { SettingsMenuComponent } from './components/settings/settings-menu/settings-menu.component'
+import { MatSidenavModule } from '@angular/material/sidenav'
+import { MatToolbarModule } from '@angular/material/toolbar'
+import { MatListModule } from '@angular/material/list'
+import { ClearCacheComponent } from './components/clear-cache/clear-cache.component'
+
+@NgModule({
+  declarations: [SettingsComponent, SettingsMenuComponent, ClearCacheComponent],
+  imports: [SettingsRoutingModule, SharedModule, MatSidenavModule, MatToolbarModule, MatListModule],
+})
+export class SettingsModule {}

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -8,6 +8,8 @@
       <a class="c-header__nav-item" (click)="navigateToRundown()" i18n>header-component.rundowns.label</a>
       <a class="c-header__nav-item" (click)="navigateToStatus()" i18n>header-component.status.label</a>
     </mat-nav-list>
+    <mat-nav-list>
+      <a class="c-header__nav-item" (click)="navigateToSettings()" i18n>rundown-overview.settings.title</a>
+    </mat-nav-list>
   </mat-toolbar-row>
 </mat-toolbar>
-

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -33,4 +33,9 @@ export class HeaderComponent {
     const segmentedPath: string[] = [Paths.STATUS]
     this.router.navigate(segmentedPath).catch(error => this.logger.data(error).warn(`Failed navigating to /${segmentedPath.join('/')}.`))
   }
+
+  public navigateToSettings(): void {
+    const segmentedPath: string[] = [Paths.SETTINGS]
+    this.router.navigate(segmentedPath).catch(error => this.logger.data(error).warn(`Failed navigating to /${segmentedPath.join('/')}.`))
+  }
 }

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -66,6 +66,18 @@
         <source>header-component.status.label</source>
         <target>Status</target>
       </trans-unit>
+      <trans-unit id="7774679192134693239" datatype="html">
+        <source>rundown-overview.settings.title</source>
+        <target state="new">Indstillinger</target>
+      </trans-unit>
+      <trans-unit id="212168824510245649" datatype="html">
+        <source>settings.action-triggers.label</source>
+        <target state="new">Action Triggers</target>
+      </trans-unit>
+      <trans-unit id="4380077604653787346" datatype="html">
+        <source>settings.clear-cache.label</source>
+        <target state="new">Ryd cache</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.en-US.xlf
+++ b/src/locale/messages.en-US.xlf
@@ -66,6 +66,18 @@
         <source>header-component.status.label</source>
         <target>Status</target>
       </trans-unit>
+      <trans-unit id="7774679192134693239" datatype="html">
+        <source>rundown-overview.settings.title</source>
+        <target state="new">Settings</target>
+      </trans-unit>
+      <trans-unit id="212168824510245649" datatype="html">
+        <source>settings.action-triggers.label</source>
+        <target state="new">Action triggers</target>
+      </trans-unit>
+      <trans-unit id="4380077604653787346" datatype="html">
+        <source>settings.clear-cache.label</source>
+        <target state="new">Clear cache</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -50,6 +50,15 @@
       <trans-unit id="9014307158606167673" datatype="html">
         <source>header-component.status.label</source>
       </trans-unit>
+      <trans-unit id="7774679192134693239" datatype="html">
+        <source>rundown-overview.settings.title</source>
+      </trans-unit>
+      <trans-unit id="212168824510245649" datatype="html">
+        <source>settings.action-triggers.label</source>
+      </trans-unit>
+      <trans-unit id="4380077604653787346" datatype="html">
+        <source>settings.clear-cache.label</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
I create a draft pool request so that the team can review the structure of the settings router and decide whether it is good. 
I use 2 different ways of loading the components, because I expect one to be quite small (only one component), and the other to be significantly larger with its own service, etc.
```
{ path: 'action-triggers', loadChildren: () => import('./action-triggers/action-triggers.module').then(module => module.ActionTriggersModule) },
      { path: 'clear-cache', component: ClearCacheComponent },
```