### PR TITLE
SOF-1754 - [W.I.P] Reset configuration cache with an endpoint request

### DIFF
--- a/src/app/settings/components/clear-cache/clear-cache.component.html
+++ b/src/app/settings/components/clear-cache/clear-cache.component.html
@@ -1,1 +1,4 @@
-Clear cache
+<button type="button"
+        class="btn"
+        (click)="actionClearConfigurationCache()">Clear configuration cache
+</button>

--- a/src/app/settings/components/clear-cache/clear-cache.component.spec.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { ClearCacheComponent } from './clear-cache.component'
+import { Logger } from '../../../core/abstractions/logger.service'
+import { instance, mock } from '@typestrong/ts-mockito'
+import { HttpConfigurationCacheService } from '../../services/http-configuration-cache.service'
 
 describe('ClearCacheComponent', () => {
   it('should create', async () => {
@@ -10,8 +13,11 @@ describe('ClearCacheComponent', () => {
 
 async function configureTestBed(): Promise<ClearCacheComponent> {
   await TestBed.configureTestingModule({
-    providers: [],
     declarations: [ClearCacheComponent],
+    providers: [
+      { provide: HttpConfigurationCacheService, useValue: instance(mock<HttpConfigurationCacheService>()) },
+      { provide: Logger, useValue: instance(mock<Logger>()) },
+    ],
   }).compileComponents()
 
   const fixture: ComponentFixture<ClearCacheComponent> = TestBed.createComponent(ClearCacheComponent)

--- a/src/app/settings/components/clear-cache/clear-cache.component.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.ts
@@ -1,8 +1,32 @@
 import { Component } from '@angular/core'
+import { Logger } from '../../../core/abstractions/logger.service'
+import { HttpConfigurationCacheService } from '../../services/http-configuration-cache.service'
 
 @Component({
   selector: 'sofie-clear-cache',
   templateUrl: './clear-cache.component.html',
   styleUrls: ['./clear-cache.component.scss'],
 })
-export class ClearCacheComponent {}
+export class ClearCacheComponent {
+  private readonly logger: Logger
+  private readonly httpConfigurationCacheService: HttpConfigurationCacheService
+  constructor(
+    logger: Logger,
+    httpConfigurationCacheService: HttpConfigurationCacheService,
+  ) {
+    this.httpConfigurationCacheService = httpConfigurationCacheService
+    this.logger = logger.tag('ClearCacheComponent')
+    this.logger.info('constructor')
+  }
+  public actionClearConfigurationCache(): void {
+    this.logger.info('actionClearConfigurationCache')
+    this.httpConfigurationCacheService.postClearConfigurationCache().subscribe({
+      next: () => {
+        this.logger.info('Post success')
+      },
+      error: err => {
+        this.logger.error('Error: ', err)
+      },
+    })
+  }
+}

--- a/src/app/settings/components/clear-cache/clear-cache.component.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.ts
@@ -10,13 +10,9 @@ import { HttpConfigurationCacheService } from '../../services/http-configuration
 export class ClearCacheComponent {
   private readonly logger: Logger
   private readonly httpConfigurationCacheService: HttpConfigurationCacheService
-  constructor(
-    logger: Logger,
-    httpConfigurationCacheService: HttpConfigurationCacheService,
-  ) {
+  constructor(logger: Logger, httpConfigurationCacheService: HttpConfigurationCacheService) {
     this.httpConfigurationCacheService = httpConfigurationCacheService
     this.logger = logger.tag('ClearCacheComponent')
-    this.logger.info('constructor')
   }
   public actionClearConfigurationCache(): void {
     this.logger.info('actionClearConfigurationCache')

--- a/src/app/settings/services/http-configuration-cache.service.spec.ts
+++ b/src/app/settings/services/http-configuration-cache.service.spec.ts
@@ -1,0 +1,21 @@
+import { instance, mock, verify } from '@typestrong/ts-mockito'
+import { Logger } from '../../core/abstractions/logger.service'
+import { HttpConfigurationCacheService } from './http-configuration-cache.service'
+import { HttpClient } from '@angular/common/http'
+import { HttpErrorService } from '../../shared/services/http/http-error.service'
+
+describe('HttpConfigurationCacheService', () => {
+  it('should be created', () => {
+    const mockLogger: Logger = mock<Logger>()
+    const mockHttpClient: HttpClient = mock<HttpClient>()
+    const mockHttpErrorService: HttpErrorService = mock<HttpErrorService>()
+    const testee: HttpConfigurationCacheService = new HttpConfigurationCacheService(
+      instance(mockLogger),
+      instance(mockHttpClient),
+      instance(mockHttpErrorService),
+    )
+    expect(testee).toBeTruthy()
+    testee.postClearConfigurationCache()
+    verify(mockHttpClient.post).once()
+  })
+})

--- a/src/app/settings/services/http-configuration-cache.service.spec.ts
+++ b/src/app/settings/services/http-configuration-cache.service.spec.ts
@@ -4,18 +4,20 @@ import { HttpConfigurationCacheService } from './http-configuration-cache.servic
 import { HttpClient } from '@angular/common/http'
 import { HttpErrorService } from '../../shared/services/http/http-error.service'
 
-describe('HttpConfigurationCacheService', () => {
-  it('should be created', () => {
-    const mockLogger: Logger = mock<Logger>()
-    const mockHttpClient: HttpClient = mock<HttpClient>()
-    const mockHttpErrorService: HttpErrorService = mock<HttpErrorService>()
-    const testee: HttpConfigurationCacheService = new HttpConfigurationCacheService(
-      instance(mockLogger),
-      instance(mockHttpClient),
-      instance(mockHttpErrorService),
-    )
-    expect(testee).toBeTruthy()
-    testee.postClearConfigurationCache()
-    verify(mockHttpClient.post).once()
+describe(HttpConfigurationCacheService.name, () => {
+  describe(HttpConfigurationCacheService.prototype.postClearConfigurationCache.name, () => {
+    it('should perform post upon invocation', () => {
+      const mockLogger: Logger = mock<Logger>()
+      const mockHttpClient: HttpClient = mock<HttpClient>()
+      const mockHttpErrorService: HttpErrorService = mock<HttpErrorService>()
+      const testee: HttpConfigurationCacheService = new HttpConfigurationCacheService(
+        instance(mockLogger),
+        instance(mockHttpClient),
+        instance(mockHttpErrorService)
+      )
+      expect(testee).toBeTruthy()
+      testee.postClearConfigurationCache()
+      verify(mockHttpClient.post).once()
+    })
   })
 })

--- a/src/app/settings/services/http-configuration-cache.service.ts
+++ b/src/app/settings/services/http-configuration-cache.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core'
+import { Logger } from '../../core/abstractions/logger.service'
+import { catchError, Observable } from 'rxjs'
+import { environment } from '../../../environments/environment'
+import { HttpClient } from '@angular/common/http'
+import { HttpErrorService } from '../../shared/services/http/http-error.service'
+
+@Injectable()
+export class HttpConfigurationCacheService {
+  private readonly logger: Logger
+  private readonly http: HttpClient
+  private readonly httpErrorService: HttpErrorService
+  constructor(logger: Logger, http: HttpClient, httpErrorService: HttpErrorService) {
+    this.logger = logger.tag('HttpConfigurationCacheService')
+    this.logger.info('constructor')
+    this.http = http
+    this.httpErrorService = httpErrorService
+  }
+
+  public postClearConfigurationCache(): Observable<void> {
+    this.logger.info('posting...')
+    return this.http.post<void>(`${environment.apiBaseUrl}/configurations/reset`, null).pipe(catchError(error => this.httpErrorService.catchError(error)))
+  }
+}

--- a/src/app/settings/services/http-configuration-cache.service.ts
+++ b/src/app/settings/services/http-configuration-cache.service.ts
@@ -8,17 +8,16 @@ import { HttpErrorService } from '../../shared/services/http/http-error.service'
 @Injectable()
 export class HttpConfigurationCacheService {
   private readonly logger: Logger
-  private readonly http: HttpClient
+  private readonly httpClient: HttpClient
   private readonly httpErrorService: HttpErrorService
-  constructor(logger: Logger, http: HttpClient, httpErrorService: HttpErrorService) {
+  constructor(logger: Logger, httpClient: HttpClient, httpErrorService: HttpErrorService) {
     this.logger = logger.tag('HttpConfigurationCacheService')
-    this.logger.info('constructor')
-    this.http = http
+    this.httpClient = httpClient
     this.httpErrorService = httpErrorService
   }
 
   public postClearConfigurationCache(): Observable<void> {
-    this.logger.info('posting...')
-    return this.http.post<void>(`${environment.apiBaseUrl}/configurations/reset`, null).pipe(catchError(error => this.httpErrorService.catchError(error)))
+    this.logger.info('postClearConfigurationCache')
+    return this.httpClient.post<void>(`${environment.apiBaseUrl}/configurations/reset`, null).pipe(catchError(error => this.httpErrorService.catchError(error)))
   }
 }

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -7,9 +7,11 @@ import { MatSidenavModule } from '@angular/material/sidenav'
 import { MatToolbarModule } from '@angular/material/toolbar'
 import { MatListModule } from '@angular/material/list'
 import { ClearCacheComponent } from './components/clear-cache/clear-cache.component'
+import { HttpConfigurationCacheService } from './services/http-configuration-cache.service'
 
 @NgModule({
   declarations: [SettingsComponent, SettingsMenuComponent, ClearCacheComponent],
+  providers: [HttpConfigurationCacheService],
   imports: [SettingsRoutingModule, SharedModule, MatSidenavModule, MatToolbarModule, MatListModule],
 })
 export class SettingsModule {}


### PR DESCRIPTION
Provides button to perform backend action to clear configuration cache by posting to the new endpoint.
Corresponds with https://github.com/tv2/sofie-server/pull/76 as backend implementation of endpoint involved.