### PR TITLE
Sof 1699/create action triggers page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ export enum Paths {
   HOME = '',
   RUNDOWNS = 'rundowns',
   STATUS = 'status',
+  SETTINGS = 'settings',
 }
 
 const routes: Routes = [
@@ -15,6 +16,10 @@ const routes: Routes = [
   {
     path: Paths.RUNDOWNS,
     loadChildren: () => import('./rundown-overview/rundown-overview.module').then(module => module.RundownOverviewModule),
+  },
+  {
+    path: Paths.SETTINGS,
+    loadChildren: () => import('./settings/settings.module').then(m => m.SettingsModule),
   },
   {
     path: `${Paths.RUNDOWNS}/:rundownId`,

--- a/src/app/helper/copy.util.ts
+++ b/src/app/helper/copy.util.ts
@@ -1,0 +1,5 @@
+export class CopyUtil {
+  public static deepCopy<T>(obj: unknown): T {
+    return JSON.parse(JSON.stringify(obj))
+  }
+}

--- a/src/app/helper/files.util.ts
+++ b/src/app/helper/files.util.ts
@@ -1,0 +1,8 @@
+export class FilesUtil {
+  public static saveText(text: string, filename: string): void {
+    var a = document.createElement('a')
+    a.setAttribute('href', 'data:text/plain;charset=utf-u,' + encodeURIComponent(text))
+    a.setAttribute('download', filename)
+    a.click()
+  }
+}

--- a/src/app/helper/icons.util.ts
+++ b/src/app/helper/icons.util.ts
@@ -1,0 +1,51 @@
+import { IconProp, SizeProp } from '@fortawesome/fontawesome-svg-core'
+import { IconButton, IconButtonSize } from '../shared/enums/icon-button'
+import { faArrowsH, faBars, faCopy, faFilter, faMinus, faPlus, faSort, faSquareCheck, faTrashCan, faXmark } from '@fortawesome/free-solid-svg-icons'
+
+export class IconsUtil {
+  public static getIconProperty(iconButton: IconButton): IconProp {
+    switch (iconButton) {
+      case IconButton.XMARK:
+        return faXmark
+      case IconButton.TRASH_CAN:
+        return faTrashCan
+      case IconButton.BARS:
+        return faBars
+      case IconButton.PLUS:
+        return faPlus
+      case IconButton.MINUS:
+        return faMinus
+      case IconButton.HORIZONTAL_ARROWS:
+        return faArrowsH
+      case IconButton.COPY:
+        return faCopy
+      case IconButton.FILTER:
+        return faFilter
+      case IconButton.SORT:
+        return faSort
+      case IconButton.SQUARE_CHECK:
+        return faSquareCheck
+      default:
+        return faXmark
+    }
+  }
+
+  public static getIconSizeProperty(iconButtonSize: IconButtonSize): SizeProp {
+    switch (iconButtonSize) {
+      case IconButtonSize.XS:
+        return 'xs'
+      case IconButtonSize.S:
+        return 'sm'
+      case IconButtonSize.M:
+        return '1x'
+      case IconButtonSize.L:
+        return 'lg'
+      case IconButtonSize.XL:
+        return 'xl'
+      case IconButtonSize.XXL:
+        return '2xl'
+      default:
+        return '1x'
+    }
+  }
+}

--- a/src/app/rundown-view/services/action-trigger-producer-key-binding.service.ts
+++ b/src/app/rundown-view/services/action-trigger-producer-key-binding.service.ts
@@ -4,7 +4,7 @@ import { KeyBinding, Keys } from 'src/app/keyboard/value-objects/key-binding'
 import { KeyBindingService } from '../abstractions/key-binding.service'
 import { ActionTriggerStateService } from '../../core/services/action-trigger-state.service'
 import { ActionStateService } from '../../shared/services/action-state.service'
-import { ActionTrigger } from '../../shared/models/action-trigger'
+import { ActionTrigger, KeyboardTriggerData } from '../../shared/models/action-trigger'
 import { Action } from '../../shared/models/action'
 import { RundownStateService } from '../../core/services/rundown-state.service'
 import { Rundown } from '../../core/models/rundown'
@@ -22,11 +22,6 @@ const SPLIT_SCREEN_COLOR: string = '#00a99c'
 const REPLAY_COLOR: string = '#8d1010'
 const VIDEO_CLIP_COLOR: string = '#1769ff'
 const GRAPHICS_COLOR: string = '#ca9d00'
-
-interface KeyboardTriggerData {
-  keys: Keys
-  actionArguments?: unknown
-}
 
 @Injectable()
 export class ActionTriggerProducerKeyBindingService implements KeyBindingService {
@@ -122,7 +117,7 @@ export class ActionTriggerProducerKeyBindingService implements KeyBindingService
 
   private createBinding(action: Tv2Action, actionTrigger: ActionTrigger<KeyboardTriggerData>, rundownId: string): StyledKeyBinding {
     return {
-      keys: actionTrigger.data.keys,
+      keys: actionTrigger.data.keys as Keys,
       label: action.name,
       onMatched: () => this.actionService.executeAction(action.id, rundownId, actionTrigger.data.actionArguments).subscribe(),
       shouldMatchOnKeyRelease: true,

--- a/src/app/settings/action-triggers/action-triggers.module.ts
+++ b/src/app/settings/action-triggers/action-triggers.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core'
+import { MatListModule } from '@angular/material/list'
+import { SharedModule } from 'src/app/shared/shared.module'
+import { ActionTriggersComponent } from './components/action-triggers/action-triggers.component'
+import { RouterModule, Routes } from '@angular/router'
+
+const routes: Routes = [{ path: '', component: ActionTriggersComponent }]
+
+@NgModule({
+  declarations: [ActionTriggersComponent],
+  imports: [SharedModule, MatListModule, RouterModule.forChild(routes)],
+})
+export class ActionTriggersModule {}

--- a/src/app/settings/action-triggers/action-triggers.module.ts
+++ b/src/app/settings/action-triggers/action-triggers.module.ts
@@ -1,13 +1,25 @@
 import { NgModule } from '@angular/core'
-import { MatListModule } from '@angular/material/list'
 import { SharedModule } from 'src/app/shared/shared.module'
 import { ActionTriggersComponent } from './components/action-triggers/action-triggers.component'
 import { RouterModule, Routes } from '@angular/router'
+import { ActionTriggersListComponent } from './components/action-triggers-list/action-triggers-list.component'
+import { EditActionTriggersComponent } from './components/edit-action-triggers/edit-action-triggers.component'
+import { HttpActionService } from 'src/app/shared/services/http/http-action.service'
+import { ActionService } from 'src/app/shared/abstractions/action.service'
+import { SelectActionTriggerComponent } from './components/edit-action-triggers/select-action-trigger/select-action-trigger.component'
+import { SingleActionTriggerBoxComponent } from './components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component'
+import { ActionTriggersImportComponent } from './components/action-triggers-import/action-triggers-import.component'
+import { HttpActionTriggerService } from 'src/app/shared/services/http/http-action-trigger.service'
+import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
 
 const routes: Routes = [{ path: '', component: ActionTriggersComponent }]
 
 @NgModule({
-  declarations: [ActionTriggersComponent],
-  imports: [SharedModule, MatListModule, RouterModule.forChild(routes)],
+  declarations: [ActionTriggersComponent, ActionTriggersListComponent, EditActionTriggersComponent, SelectActionTriggerComponent, SingleActionTriggerBoxComponent, ActionTriggersImportComponent],
+  imports: [SharedModule, RouterModule.forChild(routes)],
+  providers: [
+    { provide: ActionTriggerService, useClass: HttpActionTriggerService },
+    { provide: ActionService, useClass: HttpActionService },
+  ],
 })
 export class ActionTriggersModule {}

--- a/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.html
+++ b/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.html
@@ -1,0 +1,4 @@
+<div class="action-triggers-import">
+  <button [disabled]="disabled" class="c-sofie-button c-sofie-button-primary" (click)="fileDropRef.click()" i18n>action-triggers.import-shortcuts.button</button>
+  <input accept="application/json" [disabled]="disabled" class="action-triggers-import__input" type="file" #fileDropRef id="fileDrop" (change)="fileUpload($event, fileDropRef)" />
+</div>

--- a/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.scss
+++ b/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.scss
@@ -1,0 +1,8 @@
+:host {
+  & .action-triggers-import {
+    display: inline-block;
+    &__input {
+      display: none;
+    }
+  }
+}

--- a/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.spec.ts
+++ b/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ActionTriggersImportComponent } from './action-triggers-import.component'
+import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
+import { anything, instance, mock, when } from '@typestrong/ts-mockito'
+import { Observable, Subscription } from 'rxjs'
+import { ActionTriggerParser } from 'src/app/shared/abstractions/action-trigger-parser.service'
+import { MatSnackBar } from '@angular/material/snack-bar'
+
+describe('ActionTriggersImportComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<ActionTriggersImportComponent> {
+  const mockedActionTriggerService: ActionTriggerService = instance(createMockOfActionTriggersService())
+  const mockedActionTriggerParser: ActionTriggerParser = instance(createMockOfActionTriggerParserService())
+  const mockedMatSnackBar = mock<MatSnackBar>()
+  await TestBed.configureTestingModule({
+    providers: [
+      { provide: ActionTriggerService, useValue: mockedActionTriggerService },
+      { provide: ActionTriggerParser, useValue: mockedActionTriggerParser },
+      { provide: MatSnackBar, useValue: mockedMatSnackBar },
+    ],
+    declarations: [ActionTriggersImportComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<ActionTriggersImportComponent> = TestBed.createComponent(ActionTriggersImportComponent)
+  return fixture.componentInstance
+}
+
+function createMockOfActionTriggersService(): ActionTriggerService {
+  const mockedActionTriggersService = mock<ActionTriggerService>()
+
+  const mockedSubscription = mock<Subscription>()
+  const mockedObservable = mock<Observable<void>>()
+  when(mockedObservable.subscribe(anything)).thenReturn(instance(mockedSubscription))
+  return mockedActionTriggersService
+}
+
+function createMockOfActionTriggerParserService(): ActionTriggerParser {
+  const mockedActionTriggerParser = mock<ActionTriggerParser>()
+  const mockedSubscription = mock<Subscription>()
+  const mockedObservable = mock<Observable<void>>()
+  when(mockedObservable.subscribe(anything)).thenReturn(instance(mockedSubscription))
+  return mockedActionTriggerParser
+}

--- a/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.ts
+++ b/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.ts
@@ -1,0 +1,100 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { ActionTrigger, EditActionsTriggers, KeyboardAndSelectionTriggerData } from 'src/app/shared/models/action-trigger'
+import { MatSnackBar } from '@angular/material/snack-bar'
+import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
+import { ActionTriggerParser } from 'src/app/shared/abstractions/action-trigger-parser.service'
+
+@Component({
+  selector: 'sofie-action-triggers-import',
+  templateUrl: './action-triggers-import.component.html',
+  styleUrls: ['./action-triggers-import.component.scss'],
+})
+export class ActionTriggersImportComponent {
+  @Input() public actionsTriggersList: ActionTrigger<KeyboardAndSelectionTriggerData>[]
+  @Input() public disabled: boolean
+  @Output() private readonly startImport: EventEmitter<void> = new EventEmitter<void>()
+  @Output() private readonly importFinish: EventEmitter<void> = new EventEmitter<void>()
+  private importedActionsTriggersList: ActionTrigger<KeyboardAndSelectionTriggerData>[]
+
+  constructor(
+    private readonly actionTriggerService: ActionTriggerService,
+    private readonly actionTriggerParser: ActionTriggerParser,
+    private readonly snackBar: MatSnackBar
+  ) {}
+
+  public fileUpload(event: Event, htmlInput: HTMLInputElement): void {
+    const files = (event.target as HTMLInputElement).files
+    if (files && files[0]) {
+      const reader = new FileReader()
+      // eslint-disable-next-line
+      reader.onload = (e: any): void => {
+        try {
+          const importedActionTriggersList: ActionTrigger<KeyboardAndSelectionTriggerData>[] = this.actionTriggerParser.parseActionTriggers(JSON.parse(e.target.result))
+          if (importedActionTriggersList.length > 0) {
+            this.importedActionsTriggersList = importedActionTriggersList
+            this.startImport.emit()
+            this.importItem(0)
+          } else {
+            this.openDangerSnackBar('No items to be added')
+          }
+        } catch {
+          this.openDangerSnackBar('Error in imported file')
+        }
+        htmlInput.value = ''
+      }
+      reader.readAsText(files[0])
+    }
+  }
+
+  private isHaveNextElement(index: number): boolean {
+    return this.importedActionsTriggersList.length - 1 > index
+  }
+
+  private importItem(index: number): void {
+    if (this.actionsTriggersList.findIndex(item => item.id === this.importedActionsTriggersList[index].id) !== -1) {
+      this.updateActionTrigger(this.importedActionsTriggersList[index] as EditActionsTriggers, index)
+    } else {
+      this.createActionTrigger(this.importedActionsTriggersList[index] as EditActionsTriggers, index)
+    }
+  }
+
+  private createActionTrigger(attribute: EditActionsTriggers, index: number): void {
+    this.actionTriggerService.createActionTrigger(attribute).subscribe({
+      next: () => {
+        if (this.isHaveNextElement(index)) {
+          this.importItem(index + 1)
+        } else {
+          this.importFinish.emit()
+          this.openSnackBar('Import was successful')
+        }
+      },
+      error: () => {
+        this.openDangerSnackBar('Import fail')
+      },
+    })
+  }
+
+  private updateActionTrigger(attribute: EditActionsTriggers, index: number): void {
+    this.actionTriggerService.updateActionTrigger(attribute).subscribe({
+      next: () => {
+        if (this.isHaveNextElement(index)) {
+          this.importItem(index + 1)
+        } else {
+          this.importFinish.emit()
+          this.openSnackBar('Import was successful')
+        }
+      },
+      error: () => {
+        this.openDangerSnackBar('Import fail')
+      },
+    })
+  }
+
+  private openSnackBar(message: string): void {
+    this.snackBar.open(message, 'DISMISS', { panelClass: 'snackbar-success' })
+  }
+
+  private openDangerSnackBar(message: string): void {
+    this.snackBar.open(message, 'DISMISS', { panelClass: 'snackbar-danger' })
+  }
+}

--- a/src/app/settings/action-triggers/components/action-triggers-list/action-triggers-list.component.html
+++ b/src/app/settings/action-triggers/components/action-triggers-list/action-triggers-list.component.html
@@ -1,0 +1,51 @@
+<div class="c-action-triggers-list">
+  <div class="c-action-triggers-list__search">
+    <input type="text" [(ngModel)]="search" placeholder="Search" />
+    <sofie-dropdown-button
+      [selected]="sort"
+      [options]="sortActionsTriggers"
+      [label]="sortLabel"
+      [iconButton]="IconButton.SORT"
+      [iconButtonSize]="IconButtonSize.XL"
+      (optionSelect)="selectNewSort($event)"></sofie-dropdown-button>
+    <sofie-dropdown-button
+      [options]="selectedTriggersOptions"
+      [iconButton]="IconButton.SQUARE_CHECK"
+      [iconButtonSize]="IconButtonSize.XL"
+      (optionSelect)="actionWithSelected($event)"></sofie-dropdown-button>
+  </div>
+  <div class="c-action-triggers-list__items">
+    <ng-container *ngIf="actionsTriggersList">
+      <ng-container *ngIf="filteredActionsTriggers.length !== 0; else noItemsFound">
+        <div
+          class="c-action-triggers-list__card c-sofie-card"
+          [ngClass]="{ 'c-action-triggers-list__card--selected': selectedActionTrigger && selectedActionTrigger.id && selectedActionTrigger.id === actionsTrigger.id }"
+          *ngFor="let actionsTrigger of filteredActionsTriggers; let i = index">
+          <div class="c-action-triggers-list__card--body" (click)="selectActionTrigger(actionsTrigger)">
+            <p>
+              <strong>
+                {{ actionsTrigger.actionId }}
+              </strong>
+            </p>
+            <div>
+              <span class="c-custom-badge bg-dark">{{ actionsTrigger?.data?.keys?.join(' + ') }}</span>
+            </div>
+          </div>
+          <div class="c-action-triggers-list__card--actions">
+            <sofie-custom-checkbox
+              [selected]="actionsTrigger.data.selected ? actionsTrigger.data.selected : false"
+              [checkboxId]="actionsTrigger.id"
+              (checkboxChange)="actionTriggerCheckToggle($event, i)"></sofie-custom-checkbox>
+            <sofie-icon-button [iconButton]="IconButton.COPY" [iconButtonSize]="IconButtonSize.XL" (click)="actionTriggerCopy(actionsTrigger)"></sofie-icon-button>
+            <sofie-icon-button [iconButton]="IconButton.TRASH_CAN" [iconButtonSize]="IconButtonSize.XL" (click)="actionTriggerDelete(actionsTrigger.id)"></sofie-icon-button>
+          </div>
+        </div>
+      </ng-container>
+      <ng-template #noItemsFound>
+        <div class="c-action-triggers-list__no-items c-sofie-card">
+          <h3 i18n>action-triggers.no-shortcuts.label</h3>
+        </div>
+      </ng-template>
+    </ng-container>
+  </div>
+</div>

--- a/src/app/settings/action-triggers/components/action-triggers-list/action-triggers-list.component.scss
+++ b/src/app/settings/action-triggers/components/action-triggers-list/action-triggers-list.component.scss
@@ -1,0 +1,62 @@
+@import '../../../../../scss/sofie-vars';
+.c-action-triggers-list {
+  width: 100%;
+  &__search {
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    & input {
+      width: 100%;
+      padding: 0.5rem;
+    }
+    & sofie-dropdown-button {
+      margin-left: 1rem;
+    }
+  }
+  &__items {
+    max-height: 45rem;
+    overflow: auto;
+  }
+  &__card {
+    margin-bottom: 1rem;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    &--selected {
+      background-color: $sofie-gray;
+    }
+    &--body {
+      flex-grow: 1;
+      & p {
+        margin-top: 0;
+        margin-bottom: 8px;
+      }
+    }
+    &--actions {
+      margin-left: auto;
+      padding-left: 1rem;
+      & sofie-icon-button {
+        margin-right: 1rem;
+      }
+      & sofie-custom-checkbox {
+        margin-right: 1rem;
+      }
+    }
+  }
+  &__no-items {
+    & h3 {
+      text-align: center;
+    }
+  }
+}
+
+.c-custom-badge {
+  padding: 5px 8px;
+  border-radius: 4px;
+  display: inline-block;
+  &.bg-dark {
+    background-color: #404040;
+    color: #fff;
+  }
+}

--- a/src/app/settings/action-triggers/components/action-triggers-list/action-triggers-list.component.spec.ts
+++ b/src/app/settings/action-triggers/components/action-triggers-list/action-triggers-list.component.spec.ts
@@ -1,24 +1,32 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { ActionTriggersComponent } from './action-triggers.component'
+import { ActionTriggersListComponent } from './action-triggers-list.component'
 import { anyString, anything, instance, mock, when } from '@typestrong/ts-mockito'
 import { Observable, Subscription } from 'rxjs'
 import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
+import { DialogService } from 'src/app/shared/services/dialog.service'
+import { MatSnackBar } from '@angular/material/snack-bar'
 
-describe('ActionTriggersComponent', () => {
+describe('ActionTriggersListComponent', () => {
   it('should create', async () => {
     const component = await configureTestBed()
     expect(component).toBeTruthy()
   })
 })
 
-async function configureTestBed(): Promise<ActionTriggersComponent> {
+async function configureTestBed(): Promise<ActionTriggersListComponent> {
   const mockedActionTriggerService: ActionTriggerService = instance(createMockOfActionTriggersService())
+  const mockedDialogService = mock<DialogService>()
+  const mockedMatSnackBar = mock<MatSnackBar>()
   await TestBed.configureTestingModule({
-    providers: [{ provide: ActionTriggerService, useValue: mockedActionTriggerService }],
-    declarations: [ActionTriggersComponent],
+    providers: [
+      { provide: ActionTriggerService, useValue: mockedActionTriggerService },
+      { provide: DialogService, useValue: instance(mockedDialogService) },
+      { provide: MatSnackBar, useValue: mockedMatSnackBar },
+    ],
+    declarations: [ActionTriggersListComponent],
   }).compileComponents()
 
-  const fixture: ComponentFixture<ActionTriggersComponent> = TestBed.createComponent(ActionTriggersComponent)
+  const fixture: ComponentFixture<ActionTriggersListComponent> = TestBed.createComponent(ActionTriggersListComponent)
   return fixture.componentInstance
 }
 

--- a/src/app/settings/action-triggers/components/action-triggers-list/action-triggers-list.component.ts
+++ b/src/app/settings/action-triggers/components/action-triggers-list/action-triggers-list.component.ts
@@ -1,0 +1,174 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { MatSnackBar } from '@angular/material/snack-bar'
+import { IconButton, IconButtonSize } from 'src/app/shared/enums/icon-button'
+import { ActionTrigger, ActionTriggerSortKeys, EditActionsTriggers, KeyboardAndSelectionTriggerData, UserActionsWithSelectedTriggers } from 'src/app/shared/models/action-trigger'
+import { SofieDroppdownOptions } from 'src/app/shared/components/dropdown-button/dropdown-button.component'
+import { FilesUtil } from 'src/app/helper/files.util'
+import { DialogService } from 'src/app/shared/services/dialog.service'
+import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
+import { CopyUtil } from 'src/app/helper/copy.util'
+
+@Component({
+  selector: 'sofie-action-triggers-list',
+  templateUrl: './action-triggers-list.component.html',
+  styleUrls: ['./action-triggers-list.component.scss'],
+})
+export class ActionTriggersListComponent {
+  @Input() public actionsTriggersList: ActionTrigger<KeyboardAndSelectionTriggerData>[]
+  @Input() public selectedActionTrigger: ActionTrigger<KeyboardAndSelectionTriggerData> | null
+  @Input() public sort: ActionTriggerSortKeys
+  @Output() private readonly copyActionTrigger: EventEmitter<void> = new EventEmitter<void>()
+  @Output() private readonly actionTriggerSelect: EventEmitter<ActionTrigger<KeyboardAndSelectionTriggerData> | null> = new EventEmitter<ActionTrigger<KeyboardAndSelectionTriggerData> | null>()
+  @Output() private readonly newSortSelect: EventEmitter<ActionTriggerSortKeys> = new EventEmitter<ActionTriggerSortKeys>()
+  public search: string = ''
+  public sortLabel: string = $localize`global.sort.label`
+  public readonly IconButton = IconButton
+  public readonly IconButtonSize = IconButtonSize
+  public readonly sortActionsTriggers: SofieDroppdownOptions[] = [
+    { key: ActionTriggerSortKeys.ACTION_ID_A_Z, label: $localize`action-triggers-sort.action-id-a-z.label` },
+    { key: ActionTriggerSortKeys.ACTION_ID_Z_A, label: $localize`action-triggers-sort.action-id-z-a.label` },
+    { key: ActionTriggerSortKeys.SHORTCUT_A_Z, label: $localize`action-triggers-sort.shortcut-a-z.label` },
+    { key: ActionTriggerSortKeys.SHORTCUT_Z_A, label: $localize`action-triggers-sort.shortcut-z-a.label` },
+  ]
+
+  public readonly selectedTriggersOptions: SofieDroppdownOptions[] = [
+    { key: UserActionsWithSelectedTriggers.TOGGLE_SELECT, label: $localize`global.select-all.label`, disabled: false },
+    { key: UserActionsWithSelectedTriggers.EXPORT, label: $localize`action-triggers-sort.export-selected.label`, disabled: true },
+    { key: UserActionsWithSelectedTriggers.DELETE, label: $localize`action-triggers.delete-selected.label`, disabled: true },
+  ]
+  public selectedCount: number = 0
+
+  constructor(
+    private readonly actionTriggerService: ActionTriggerService,
+    private readonly dialogService: DialogService,
+    private readonly snackBar: MatSnackBar
+  ) {}
+
+  get filteredActionsTriggers(): ActionTrigger<KeyboardAndSelectionTriggerData>[] {
+    return this.actionsTriggersList.filter(trigger => trigger.actionId.toLocaleLowerCase().includes(this.search.toLocaleLowerCase()) || trigger.id === this.selectedActionTrigger?.id)
+  }
+
+  public selectActionTrigger(actionTrigger: ActionTrigger<KeyboardAndSelectionTriggerData> | null): void {
+    if (this.selectedActionTrigger?.id === actionTrigger?.id) {
+      this.actionTriggerSelect.emit(null)
+    } else {
+      this.actionTriggerSelect.emit(actionTrigger)
+    }
+  }
+
+  public actionTriggerCheckToggle(isSelected: boolean, index: number): void {
+    this.actionsTriggersList[index].data.selected = isSelected
+    this.checkSelectedCount()
+  }
+
+  public actionTriggerDelete(actionTriggerId: string): void {
+    this.dialogService.createConfirmDialog($localize`global.delete.label`, $localize`action-triggers.delete.confirmation`, 'Delete', () => this.deleteActionTriggerById(actionTriggerId))
+  }
+
+  public deleteActionTriggerById(actionTriggerId: string, deleteAllSelected?: boolean): void {
+    this.actionTriggerService.deleteActionTrigger(actionTriggerId).subscribe({
+      next: () => {
+        if (this.selectedActionTrigger?.id === actionTriggerId) {
+          this.actionTriggerSelect.emit(null)
+        }
+        this.actionsTriggersList = this.actionsTriggersList.filter(action => action.id !== actionTriggerId)
+        if (deleteAllSelected && this.selectedActionTriggers.length > 0) {
+          this.deleteActionTriggerById(this.selectedActionTriggers[0].id, true)
+        } else {
+          if (deleteAllSelected) this.selectedCount = 0
+          this.openSnackBar('Success delete')
+        }
+      },
+      error: () => {
+        this.openDangerSnackBar('Fail to delete')
+      },
+    })
+  }
+
+  public actionTriggerCopy(actionTrigger: ActionTrigger<KeyboardAndSelectionTriggerData>): void {
+    const copyPayload: EditActionsTriggers = { actionId: actionTrigger.actionId, data: { keys: actionTrigger.data.keys, actionArguments: actionTrigger.data.actionArguments as number } }
+    this.actionTriggerService.createActionTrigger(copyPayload).subscribe({
+      next: () => {
+        this.copyActionTrigger.emit()
+        this.openSnackBar('Success copy')
+      },
+      error: () => {
+        this.openDangerSnackBar('Fail to copy')
+      },
+    })
+  }
+
+  public selectNewSort(sortOption: string): void {
+    this.newSortSelect.emit(sortOption as ActionTriggerSortKeys)
+  }
+
+  public actionWithSelected(userAction: string): void {
+    if (userAction === UserActionsWithSelectedTriggers.DELETE) {
+      this.dialogService.createConfirmDialog($localize`action-triggers.delete-selected.label`, $localize`action-triggers.delete-selected.confirmation`, 'Delete', () =>
+        this.deleteActionTriggerById(this.selectedActionTriggers[0].id, true)
+      )
+    } else if (userAction === UserActionsWithSelectedTriggers.EXPORT) {
+      this.exportSelectedTriggers()
+    } else if (userAction === UserActionsWithSelectedTriggers.TOGGLE_SELECT) {
+      this.toggleSelectUnselectAll()
+    }
+  }
+
+  private get selectedActionTriggers(): ActionTrigger<KeyboardAndSelectionTriggerData>[] {
+    return this.actionsTriggersList.filter(item => item.data.selected)
+  }
+
+  private checkSelectedCount(): void {
+    this.selectedCount = this.actionsTriggersList.filter(item => item.data.selected).length
+    const toggleSelectIndex = this.selectedTriggersOptions.findIndex(item => item.key === UserActionsWithSelectedTriggers.TOGGLE_SELECT)
+    this.selectedTriggersOptions.forEach(option => {
+      if (option.key === UserActionsWithSelectedTriggers.TOGGLE_SELECT) {
+        if (this.selectedCount === this.actionsTriggersList.length) {
+          this.selectedTriggersOptions[toggleSelectIndex].label = $localize`global.unselect-all.label`
+        } else {
+          this.selectedTriggersOptions[toggleSelectIndex].label = $localize`global.select-all.label`
+        }
+      }
+      if (option.key === UserActionsWithSelectedTriggers.EXPORT || option.key === UserActionsWithSelectedTriggers.DELETE) {
+        if (this.selectedCount > 0) {
+          option.disabled = false
+        } else {
+          option.disabled = true
+        }
+      }
+    })
+  }
+
+  private exportSelectedTriggers(): void {
+    const triggersCopy: ActionTrigger<KeyboardAndSelectionTriggerData>[] = CopyUtil.deepCopy(this.selectedActionTriggers)
+    triggersCopy.map(trigger => delete trigger.data.selected)
+    FilesUtil.saveText(JSON.stringify(triggersCopy), 'selected-actions-triggers.json')
+    this.unselectAllActionsTriggers()
+    this.checkSelectedCount()
+  }
+
+  private toggleSelectUnselectAll(): void {
+    if (this.selectedCount === this.actionsTriggersList.length) {
+      this.unselectAllActionsTriggers()
+    } else {
+      this.selectAllActionsTriggers()
+    }
+    this.checkSelectedCount()
+  }
+
+  private unselectAllActionsTriggers(): void {
+    this.selectedActionTriggers.forEach(trigger => (trigger.data.selected = false))
+  }
+
+  private selectAllActionsTriggers(): void {
+    this.actionsTriggersList.forEach(trigger => (trigger.data.selected = true))
+  }
+
+  private openSnackBar(message: string): void {
+    this.snackBar.open(message, 'DISMISS', { panelClass: 'snackbar-success' })
+  }
+
+  private openDangerSnackBar(message: string): void {
+    this.snackBar.open(message, 'DISMISS', { panelClass: 'snackbar-danger' })
+  }
+}

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.html
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.html
@@ -1,3 +1,31 @@
-<div class="c-action-triggers">
-  <h2>keyboard shortcuts</h2>
+<div class="c-actions-triggers">
+  <div class="c-actions-triggers__header">
+    <h2 i18n>action-triggers.keyboard-shortcuts.label</h2>
+    <div>
+      <button class="c-sofie-button c-sofie-button-primary" (click)="createActionTrigger()" i18n>action-triggers.create-shortcut.button</button>
+      <button class="c-sofie-button c-sofie-button-primary" (click)="exportActionsTriggers()" i18n>action-triggers.export-shortcuts.button</button>
+      <sofie-action-triggers-import [actionsTriggersList]="actionsTriggersList" [disabled]="loading" (startImport)="importStart()" (importFinish)="editActionTrigger()"></sofie-action-triggers-import>
+    </div>
+  </div>
+
+  <ng-container *ngIf="!loading; else loader">
+    <div class="c-actions-triggers__body">
+      <div class="c-actions-triggers__body--list">
+        <sofie-action-triggers-list
+          [actionsTriggersList]="actionsTriggersList"
+          [selectedActionTrigger]="selectedAction"
+          [sort]="sort"
+          (newSortSelect)="newSortSelect($event)"
+          (actionTriggerSelect)="actionTriggerSelect($event)"
+          (copyActionTrigger)="editActionTrigger()"></sofie-action-triggers-list>
+      </div>
+      <div *ngIf="selectedAction || createAction" class="c-actions-triggers__body--edit">
+        <sofie-edit-action-triggers (editActionTrigger)="editActionTrigger()" (cancelActionTrigger)="cancelActionTrigger()" [selectedActionTrigger]="selectedAction"></sofie-edit-action-triggers>
+      </div>
+    </div>
+  </ng-container>
 </div>
+
+<ng-template #loader>
+  <sofie-loading></sofie-loading>
+</ng-template>

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.html
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.html
@@ -1,0 +1,3 @@
+<div class="c-action-triggers">
+  <h2>keyboard shortcuts</h2>
+</div>

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.scss
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.scss
@@ -1,0 +1,29 @@
+.c-actions-triggers {
+  padding: 2rem;
+  &__header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    & h2 {
+      margin: 0 auto 0 0;
+    }
+    & button {
+      margin-right: 16px;
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+  &__body {
+    display: flex;
+    &--list {
+      flex: 0 0 30%;
+      flex-grow: 1;
+      min-width: 25rem;
+      margin-right: 1rem;
+    }
+    &--edit {
+      flex: 0 0 70%;
+    }
+  }
+}

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.spec.ts
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ActionTriggersComponent } from './action-triggers.component'
+
+describe('ActionTriggersComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<ActionTriggersComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [ActionTriggersComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<ActionTriggersComponent> = TestBed.createComponent(ActionTriggersComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.ts
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-action-triggers',
+  templateUrl: './action-triggers.component.html',
+  styleUrls: ['./action-triggers.component.scss'],
+})
+export class ActionTriggersComponent {}

--- a/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.ts
+++ b/src/app/settings/action-triggers/components/action-triggers/action-triggers.component.ts
@@ -1,8 +1,88 @@
-import { Component } from '@angular/core'
+import { Component, OnInit } from '@angular/core'
+import { ActionTrigger, ActionTriggerSortKeys, KeyboardAndSelectionTriggerData } from 'src/app/shared/models/action-trigger'
+import { FilesUtil } from 'src/app/helper/files.util'
+import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
+import { CopyUtil } from 'src/app/helper/copy.util'
 
 @Component({
   selector: 'sofie-action-triggers',
   templateUrl: './action-triggers.component.html',
   styleUrls: ['./action-triggers.component.scss'],
 })
-export class ActionTriggersComponent {}
+export class ActionTriggersComponent implements OnInit {
+  public selectedAction: ActionTrigger<KeyboardAndSelectionTriggerData> | null
+  public createAction: boolean
+  public loading: boolean
+  public actionsTriggersList: ActionTrigger<KeyboardAndSelectionTriggerData>[]
+  public sort: ActionTriggerSortKeys = ActionTriggerSortKeys.ACTION_ID_A_Z
+
+  constructor(private readonly actionTriggerService: ActionTriggerService) {}
+
+  public ngOnInit(): void {
+    this.loadActionsTriggers()
+  }
+
+  private loadActionsTriggers(): void {
+    this.loading = true
+    this.actionTriggerService.getActionTriggers().subscribe({
+      next: triggers => {
+        this.actionsTriggersList = triggers.map(trigger => {
+          return { ...trigger, ...{ data: { selected: false, ...trigger.data } } }
+        })
+        this.newSortSelect(this.sort)
+        this.loading = false
+      },
+    })
+  }
+
+  public editActionTrigger(): void {
+    this.loadActionsTriggers()
+    this.cancelActionTrigger()
+  }
+
+  public importStart(): void {
+    this.loading = true
+  }
+
+  public actionTriggerSelect(selectedTrigger: ActionTrigger<KeyboardAndSelectionTriggerData> | null): void {
+    this.selectedAction = selectedTrigger
+    this.createAction = false
+  }
+
+  public createActionTrigger(): void {
+    this.createAction = true
+    this.selectedAction = null
+  }
+
+  public cancelActionTrigger(): void {
+    this.selectedAction = null
+    this.createAction = false
+  }
+
+  public newSortSelect(sort: ActionTriggerSortKeys): void {
+    this.sort = sort
+    switch (sort) {
+      case ActionTriggerSortKeys.ACTION_ID_A_Z:
+        this.actionsTriggersList = this.actionsTriggersList.sort((a, b) => a.actionId.localeCompare(b.actionId))
+        break
+      case ActionTriggerSortKeys.ACTION_ID_Z_A:
+        this.actionsTriggersList = this.actionsTriggersList.sort((a, b) => b.actionId.localeCompare(a.actionId))
+        break
+      case ActionTriggerSortKeys.SHORTCUT_A_Z:
+        this.actionsTriggersList = this.actionsTriggersList.sort((a, b) => a.data?.keys.toString().localeCompare(b.data?.keys.toString()))
+        break
+      case ActionTriggerSortKeys.SHORTCUT_Z_A:
+        this.actionsTriggersList = this.actionsTriggersList.sort((a, b) => b.data?.keys.toString().localeCompare(a.data?.keys.toString()))
+        break
+      default:
+        this.actionsTriggersList = this.actionsTriggersList.sort((a, b) => a.actionId.localeCompare(b.actionId))
+        break
+    }
+  }
+
+  public exportActionsTriggers(): void {
+    const triggersCopy: ActionTrigger<KeyboardAndSelectionTriggerData>[] = CopyUtil.deepCopy(this.actionsTriggersList)
+    triggersCopy.map(trigger => delete trigger.data.selected)
+    FilesUtil.saveText(JSON.stringify(triggersCopy), 'actions-triggers.json')
+  }
+}

--- a/src/app/settings/action-triggers/components/edit-action-triggers/edit-action-triggers.component.html
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/edit-action-triggers.component.html
@@ -1,0 +1,33 @@
+<div class="c-edit-actions-triggers">
+  <h4>
+    <span *ngIf="isUpdateAction; else createLabel" i18n>action-triggers.update-shortcut.title</span>
+    <ng-template #createLabel><span i18n>action-triggers.create-shortcut.title</span></ng-template>
+  </h4>
+  <form class="c-edit-actions-triggers__form" *ngIf="!loading; else loader" (ngSubmit)="submit()" [formGroup]="actionForm">
+    <div>
+      <ng-container formGroupName="data">
+        <div class="c-edit-actions-triggers__form--field c-sofie-form-control" [ngClass]="{ 'c-sofie-control-error': showErrorFor('keys', 'data') }">
+          <label i18n>action-triggers.shortcut.label</label>
+          <input [readonly]="true" (keydown)="onKeyDown($event)" (keyup)="onKeyUp()" formControlName="keys" />
+        </div>
+        <div class="c-edit-actions-triggers__form--field c-sofie-form-control" [ngClass]="{ 'c-sofie-control-error': showErrorFor('actionArguments', 'data') }">
+          <label i18n>action-triggers.action-argument.label</label>
+          <input [readonly]="submitting" formControlName="actionArguments" />
+        </div>
+      </ng-container>
+
+      <div class="c-edit-actions-triggers__form--field c-sofie-form-control" [ngClass]="{ 'c-sofie-control-error': showErrorFor('actionId') }">
+        <label i18n>action-triggers.selected-action-id.label</label>
+        <input [readonly]="true" formControlName="actionId" />
+      </div>
+      <div class="c-edit-actions-triggers__form--buttons">
+        <button class="c-sofie-button c-sofie-button-gray" type="submit" i18n>global.save.button</button>
+        <button class="c-sofie-button c-sofie-button-gray" (click)="cancelEdit()" type="button" i18n>global.cancel.button</button>
+      </div>
+    </div>
+    <sofie-select-action-trigger [actions]="actions" [selectedActionId]="actionForm.get('actionId')?.value" (selectActionTrigger)="selectNewActionTrigger($event)"></sofie-select-action-trigger>
+  </form>
+</div>
+<ng-template #loader>
+  <sofie-loading></sofie-loading>
+</ng-template>

--- a/src/app/settings/action-triggers/components/edit-action-triggers/edit-action-triggers.component.scss
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/edit-action-triggers.component.scss
@@ -1,0 +1,33 @@
+@import '../../../../../scss/sofie-vars';
+.c-edit-actions-triggers {
+  padding-left: 1rem;
+  border-left: 1px solid $sofie-gray;
+  height: 100%;
+  & h4 {
+    margin-top: 0;
+    font-size: 2rem;
+  }
+
+  &__form {
+    display: flex;
+    & > div {
+      flex: 0 0 35%;
+      display: flex;
+      flex-direction: column;
+    }
+    &--field {
+      width: 100%;
+    }
+    &--buttons {
+      margin-top: auto;
+      & button {
+        display: block;
+        margin-bottom: 1rem;
+        width: 100%;
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}

--- a/src/app/settings/action-triggers/components/edit-action-triggers/edit-action-triggers.component.spec.ts
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/edit-action-triggers.component.spec.ts
@@ -1,24 +1,33 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { ActionTriggersComponent } from './action-triggers.component'
+import { EditActionTriggersComponent } from './edit-action-triggers.component'
+import { ReactiveFormsModule } from '@angular/forms'
 import { anyString, anything, instance, mock, when } from '@typestrong/ts-mockito'
-import { Observable, Subscription } from 'rxjs'
+import { MatSnackBar } from '@angular/material/snack-bar'
 import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
+import { Observable, Subscription } from 'rxjs'
+import { ActionService } from 'src/app/shared/abstractions/action.service'
 
-describe('ActionTriggersComponent', () => {
+describe('EditActionTriggersComponent', () => {
   it('should create', async () => {
     const component = await configureTestBed()
     expect(component).toBeTruthy()
   })
 })
 
-async function configureTestBed(): Promise<ActionTriggersComponent> {
+async function configureTestBed(): Promise<EditActionTriggersComponent> {
+  const mockedMatSnackBar = mock<MatSnackBar>()
   const mockedActionTriggerService: ActionTriggerService = instance(createMockOfActionTriggersService())
   await TestBed.configureTestingModule({
-    providers: [{ provide: ActionTriggerService, useValue: mockedActionTriggerService }],
-    declarations: [ActionTriggersComponent],
+    providers: [
+      { provide: MatSnackBar, useValue: mockedMatSnackBar },
+      { provide: ActionTriggerService, useValue: mockedActionTriggerService },
+      { provide: ActionService, useValue: instance(mock<ActionService>()) },
+    ],
+    declarations: [EditActionTriggersComponent],
+    imports: [ReactiveFormsModule],
   }).compileComponents()
 
-  const fixture: ComponentFixture<ActionTriggersComponent> = TestBed.createComponent(ActionTriggersComponent)
+  const fixture: ComponentFixture<EditActionTriggersComponent> = TestBed.createComponent(EditActionTriggersComponent)
   return fixture.componentInstance
 }
 
@@ -28,6 +37,6 @@ function createMockOfActionTriggersService(): ActionTriggerService {
   const mockedObservable = mock<Observable<void>>()
   when(mockedObservable.subscribe(anything)).thenReturn(instance(mockedSubscription))
   when(mockedActionTriggersService.createActionTrigger(anyString())).thenResolve()
-  when(mockedActionTriggersService.deleteActionTrigger(anyString())).thenResolve()
+  when(mockedActionTriggersService.updateActionTrigger(anyString())).thenResolve()
   return mockedActionTriggersService
 }

--- a/src/app/settings/action-triggers/components/edit-action-triggers/edit-action-triggers.component.ts
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/edit-action-triggers.component.ts
@@ -1,0 +1,171 @@
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChange, SimpleChanges } from '@angular/core'
+import { AbstractControl, FormBuilder, UntypedFormGroup, Validators } from '@angular/forms'
+import { ActionTrigger, EditActionsTriggers, KeyboardAndSelectionTriggerData } from 'src/app/shared/models/action-trigger'
+import { ActionService } from 'src/app/shared/abstractions/action.service'
+import { Tv2PartAction } from 'src/app/shared/models/tv2-action'
+import { MatSnackBar } from '@angular/material/snack-bar'
+import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
+
+export interface ActionTriggerUIForm {
+  actionId: string
+  data: {
+    keys: string
+    actionArguments: number
+  }
+}
+
+@Component({
+  selector: 'sofie-edit-action-triggers',
+  templateUrl: './edit-action-triggers.component.html',
+  styleUrls: ['./edit-action-triggers.component.scss'],
+})
+export class EditActionTriggersComponent implements OnChanges, OnInit {
+  @Output() private readonly cancelActionTrigger: EventEmitter<void> = new EventEmitter<void>()
+  @Output() private readonly editActionTrigger: EventEmitter<void> = new EventEmitter<void>()
+  @Input() public selectedActionTrigger: ActionTrigger<KeyboardAndSelectionTriggerData> | null
+  public submitting: boolean = false
+  public submitted: boolean = false
+  public actions: Tv2PartAction[]
+  public loading: boolean = false
+  public keyPress: boolean = false
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly actionTriggerService: ActionTriggerService,
+    private readonly actionService: ActionService,
+    private readonly snackBar: MatSnackBar
+  ) {}
+
+  public actionForm: UntypedFormGroup = this.fb.group({
+    actionId: ['', [Validators.required]],
+    data: this.fb.group({
+      keys: ['', [Validators.required]],
+      actionArguments: '',
+    }),
+  })
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    const actionChange: SimpleChange | undefined = changes['selectedActionTrigger']
+    if (actionChange) {
+      const action: ActionTrigger<KeyboardAndSelectionTriggerData> | null = actionChange.currentValue
+      if (action) {
+        this.patchValue(action)
+      } else {
+        this.actionForm.reset()
+      }
+    }
+  }
+
+  public ngOnInit(): void {
+    this.loading = true
+    this.actionService.getActions('jSXbtcsHTPjebGXurMzP401Z3u0_').subscribe({
+      next: loadedActions => {
+        this.actions = loadedActions as Tv2PartAction[]
+        this.loading = false
+      },
+    })
+  }
+
+  private patchValue(actionValue: ActionTrigger<KeyboardAndSelectionTriggerData>): void {
+    this.actionForm.patchValue({ actionId: actionValue.actionId, data: { keys: actionValue.data.keys.join(' + '), actionArguments: actionValue.data.actionArguments } })
+  }
+
+  public onKeyDown(event: KeyboardEvent): void {
+    event.preventDefault()
+    if (this.keyPress) {
+      const currentKeys: string[] = this.actionForm?.get('data')?.get('keys')?.value ? this.actionForm?.get('data')?.get('keys')?.value.split(' + ') : []
+      if (currentKeys.findIndex(keyCode => keyCode === event.code) === -1) {
+        currentKeys.push(event.code)
+        this.actionForm?.get('data')?.get('keys')?.patchValue(currentKeys.join(' + '))
+      }
+    } else {
+      this.actionForm?.get('data')?.get('keys')?.patchValue(event.code)
+      this.keyPress = true
+    }
+  }
+
+  public selectNewActionTrigger(action: Tv2PartAction): void {
+    this.actionForm.patchValue({ actionId: action.id })
+  }
+
+  public onKeyUp(): void {
+    this.keyPress = false
+  }
+
+  public get isUpdateAction(): boolean {
+    return !!this.selectedActionTrigger
+  }
+
+  public submit(): void {
+    this.submitted = true
+    if (this.actionForm.invalid) {
+      this.actionForm.markAllAsTouched()
+      return
+    }
+    this.submitting = true
+    const actionTriggerValue = this.prepareSendData(this.actionForm.value)
+    if (this.isUpdateAction) {
+      this.updateActionTrigger({ ...actionTriggerValue, id: this.selectedActionTrigger?.id })
+    } else {
+      this.createActionTrigger(actionTriggerValue)
+    }
+  }
+
+  private prepareSendData(formData: ActionTriggerUIForm): EditActionsTriggers {
+    const keysArray: string[] = formData.data?.keys?.split(' + ')
+    const resultData: EditActionsTriggers = { actionId: formData.actionId, data: { keys: keysArray, actionArguments: +formData.data.actionArguments } }
+    return resultData
+  }
+
+  private createActionTrigger(attribute: EditActionsTriggers): void {
+    this.actionTriggerService.createActionTrigger(attribute).subscribe({
+      next: () => {
+        this.submitting = false
+        this.editActionTrigger.emit()
+        this.openSnackBar('Success create')
+      },
+      error: () => {
+        this.submitting = false
+        this.openDangerSnackBar('Fail to create')
+      },
+    })
+  }
+
+  private updateActionTrigger(attribute: EditActionsTriggers): void {
+    this.actionTriggerService.updateActionTrigger(attribute).subscribe({
+      next: () => {
+        this.submitting = false
+        this.editActionTrigger.emit()
+        this.openSnackBar('Success update')
+      },
+      error: () => {
+        this.submitting = false
+        this.openDangerSnackBar('Fail to update')
+      },
+    })
+  }
+
+  private openSnackBar(message: string): void {
+    this.snackBar.open(message, 'DISMISS', { panelClass: 'snackbar-success' })
+  }
+
+  private openDangerSnackBar(message: string): void {
+    this.snackBar.open(message, 'DISMISS', { panelClass: 'snackbar-danger' })
+  }
+
+  public cancelEdit(): void {
+    this.cancelActionTrigger.emit()
+  }
+
+  public control(name: string): AbstractControl {
+    return this.actionForm.controls[name]
+  }
+
+  public showErrorFor(name: string, groupName?: string): boolean | undefined {
+    if (!!groupName) {
+      return this.actionForm.get(groupName)?.get(name)?.invalid && this.actionForm.get(groupName)?.get(name)?.touched
+    } else {
+      return this.control(name).invalid && this.control(name).touched
+    }
+  }
+}

--- a/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/select-action-trigger.component.html
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/select-action-trigger.component.html
@@ -1,0 +1,20 @@
+<div class="c-select-actions-triggers c-sofie-card">
+  <div class="c-select-actions-triggers__field">
+    <input [readonly]="submitting" placeholder="Search" [(ngModel)]="search" />
+  </div>
+  <div class="c-select-actions-triggers__list">
+    <div>
+      <ng-container *ngIf="filteredActions.length > 0; else noActions">
+        <sofie-single-action-trigger-box
+          *ngFor="let action of filteredActions"
+          [action]="action"
+          [isSelected]="action.id === selectedActionId"
+          [submitting]="submitting"
+          (actionSelect)="newActionSelected($event)"></sofie-single-action-trigger-box>
+      </ng-container>
+      <ng-template #noActions>
+        <h4 class="text-center" i18n>action-triggers.no-actions.label</h4>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/select-action-trigger.component.scss
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/select-action-trigger.component.scss
@@ -1,0 +1,37 @@
+@import '../../../../../../scss/sofie-vars';
+:host {
+  flex-grow: 2;
+  padding-left: 2rem;
+  max-width: 50rem;
+  & .c-select-actions-triggers {
+    width: 100%;
+    &__field {
+      width: 100%;
+      margin-bottom: 1rem;
+      & input {
+        width: 100%;
+      }
+    }
+    &__list {
+      height: 30rem;
+      overflow: auto;
+      border-right: 1px solid $sofie-gray;
+      & > div {
+        display: flex;
+        flex-wrap: wrap;
+        & sofie-single-action-trigger-box {
+          flex: 0 0 15%;
+          min-width: 4rem;
+          max-width: 7rem;
+          height: 5rem;
+          border-radius: 10px;
+          margin-bottom: 0.5rem;
+          margin-right: 0.5rem;
+        }
+        & h4 {
+          flex: 0 0 100%;
+        }
+      }
+    }
+  }
+}

--- a/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/select-action-trigger.component.spec.ts
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/select-action-trigger.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { SelectActionTriggerComponent } from './select-action-trigger.component'
+
+describe('SelectActionTriggerComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<SelectActionTriggerComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [SelectActionTriggerComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<SelectActionTriggerComponent> = TestBed.createComponent(SelectActionTriggerComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/select-action-trigger.component.ts
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/select-action-trigger.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { Tv2PartAction } from 'src/app/shared/models/tv2-action'
+
+@Component({
+  selector: 'sofie-select-action-trigger',
+  templateUrl: './select-action-trigger.component.html',
+  styleUrls: ['./select-action-trigger.component.scss'],
+})
+export class SelectActionTriggerComponent {
+  @Output() private readonly selectActionTrigger: EventEmitter<Tv2PartAction> = new EventEmitter<Tv2PartAction>()
+  @Input() public actions: Tv2PartAction[]
+  @Input() public selectedActionId: string | undefined
+  @Input() public submitting: boolean
+  public search: string = ''
+
+  public newActionSelected(action: Tv2PartAction): void {
+    this.selectActionTrigger.emit(action)
+  }
+
+  get filteredActions(): Tv2PartAction[] {
+    return this.actions.filter(action => action.name.toLocaleLowerCase().includes(this.search.toLocaleLowerCase()) || action.id === this.selectedActionId)
+  }
+}

--- a/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component.html
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component.html
@@ -1,0 +1,7 @@
+<div
+  (click)="selectNewAction()"
+  class="c-sofie-card c-action-trigger-box"
+  [ngClass]="{ 'c-action-trigger-selected': isSelected }"
+  [class]="this.action.metadata.contentType.toLocaleLowerCase() + '_color'">
+  {{ action.name }}
+</div>

--- a/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component.scss
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component.scss
@@ -1,0 +1,11 @@
+@import '../../../../../../../scss/sofie-vars';
+:host {
+  & .c-action-trigger-box {
+    height: 100%;
+    cursor: pointer;
+    &.c-action-trigger-selected {
+      background: $sofie-danger;
+      color: #fff;
+    }
+  }
+}

--- a/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component.spec.ts
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { SingleActionTriggerBoxComponent } from './single-action-trigger-box.component'
+
+describe('SingleActionTriggerBoxComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<SingleActionTriggerBoxComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [SingleActionTriggerBoxComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<SingleActionTriggerBoxComponent> = TestBed.createComponent(SingleActionTriggerBoxComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component.ts
+++ b/src/app/settings/action-triggers/components/edit-action-triggers/select-action-trigger/single-action-trigger-box/single-action-trigger-box.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
+import { Tv2PartAction } from 'src/app/shared/models/tv2-action'
+
+@Component({
+  selector: 'sofie-single-action-trigger-box',
+  templateUrl: './single-action-trigger-box.component.html',
+  styleUrls: ['./single-action-trigger-box.component.scss'],
+})
+export class SingleActionTriggerBoxComponent implements OnInit {
+  @Output() private readonly actionSelect: EventEmitter<Tv2PartAction> = new EventEmitter<Tv2PartAction>()
+  @Input() public action: Tv2PartAction
+  @Input() public isSelected: boolean
+  @Input() public submitting: boolean
+  public classExpression: string
+
+  public ngOnInit(): void {
+    this.classExpression = this.action.metadata.contentType
+  }
+
+  public selectNewAction(): void {
+    this.actionSelect.emit(this.action)
+  }
+}

--- a/src/app/settings/components/clear-cache/clear-cache.component.html
+++ b/src/app/settings/components/clear-cache/clear-cache.component.html
@@ -1,0 +1,1 @@
+Clear cache

--- a/src/app/settings/components/clear-cache/clear-cache.component.spec.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ClearCacheComponent } from './clear-cache.component'
+
+describe('ClearCacheComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<ClearCacheComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [ClearCacheComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<ClearCacheComponent> = TestBed.createComponent(ClearCacheComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/components/clear-cache/clear-cache.component.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-clear-cache',
+  templateUrl: './clear-cache.component.html',
+  styleUrls: ['./clear-cache.component.scss'],
+})
+export class ClearCacheComponent {}

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.html
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.html
@@ -1,0 +1,8 @@
+<mat-toolbar class="c-side-bar">
+  <mat-nav-list class="c-side-bar__nav-item">
+    <a routerLinkActive="active-tab" [routerLink]="['/settings/action-triggers']" i18n>settings.action-triggers.label</a>
+  </mat-nav-list>
+  <mat-nav-list class="c-side-bar__nav-item">
+    <a routerLinkActive="active-tab" [routerLink]="['/settings/clear-cache']" i18n>settings.clear-cache.label</a>
+  </mat-nav-list>
+</mat-toolbar>

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.html
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.html
@@ -1,8 +1,8 @@
-<mat-toolbar class="c-side-bar">
-  <mat-nav-list class="c-side-bar__nav-item">
+<div class="c-side-bar">
+  <div class="c-side-bar__nav-item">
     <a routerLinkActive="active-tab" [routerLink]="['/settings/action-triggers']" i18n>settings.action-triggers.label</a>
-  </mat-nav-list>
-  <mat-nav-list class="c-side-bar__nav-item">
+  </div>
+  <div class="c-side-bar__nav-item">
     <a routerLinkActive="active-tab" [routerLink]="['/settings/clear-cache']" i18n>settings.clear-cache.label</a>
-  </mat-nav-list>
-</mat-toolbar>
+  </div>
+</div>

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.scss
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.scss
@@ -1,21 +1,23 @@
 .c-side-bar {
   --text-color: white;
-  width: 220px;
+  width: 100%;
   display: flex;
   flex-direction: column;
-  height: auto;
+  height: 100%;
   background-color: transparent;
   align-items: flex-start;
   padding: 0;
+  border-right: 1px solid #d3d3d3;
 
   &__nav-item {
     font-weight: lighter;
     width: 100%;
     padding-top: 0;
     a {
-      padding: 0.5rem 1em;
+      padding: 0.8rem 1em;
       font-size: medium;
       display: block;
+      text-decoration: none;
       &.active-tab {
         background-color: #343434;
         color: #5ebaf4;

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.scss
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.scss
@@ -1,0 +1,30 @@
+.c-side-bar {
+  --text-color: white;
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  height: auto;
+  background-color: transparent;
+  align-items: flex-start;
+  padding: 0;
+
+  &__nav-item {
+    font-weight: lighter;
+    width: 100%;
+    padding-top: 0;
+    a {
+      padding: 0.5rem 1em;
+      font-size: medium;
+      display: block;
+      &.active-tab {
+        background-color: #343434;
+        color: #5ebaf4;
+      }
+    }
+  }
+
+  &__nav-item:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.scss
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../scss/sofie-vars';
+
 .c-side-bar {
   --text-color: white;
   width: 100%;
@@ -7,7 +9,7 @@
   background-color: transparent;
   align-items: flex-start;
   padding: 0;
-  border-right: 1px solid #d3d3d3;
+  border-right: 1px solid $sofie-gray;
 
   &__nav-item {
     font-weight: lighter;

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.spec.ts
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { SettingsMenuComponent } from './settings-menu.component'
+
+describe('SettingsMenuComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<SettingsMenuComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [SettingsMenuComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<SettingsMenuComponent> = TestBed.createComponent(SettingsMenuComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/components/settings/settings-menu/settings-menu.component.ts
+++ b/src/app/settings/components/settings/settings-menu/settings-menu.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-settings-menu',
+  templateUrl: './settings-menu.component.html',
+  styleUrls: ['./settings-menu.component.scss'],
+})
+export class SettingsMenuComponent {}

--- a/src/app/settings/components/settings/settings.component.html
+++ b/src/app/settings/components/settings/settings.component.html
@@ -1,0 +1,6 @@
+<sofie-header></sofie-header>
+
+<mat-drawer-container class="c-settings">
+  <mat-drawer mode="side" opened><sofie-settings-menu></sofie-settings-menu></mat-drawer>
+  <mat-drawer-content><router-outlet></router-outlet></mat-drawer-content>
+</mat-drawer-container>

--- a/src/app/settings/components/settings/settings.component.html
+++ b/src/app/settings/components/settings/settings.component.html
@@ -1,6 +1,6 @@
 <sofie-header></sofie-header>
 
-<mat-drawer-container class="c-settings">
-  <mat-drawer mode="side" opened><sofie-settings-menu></sofie-settings-menu></mat-drawer>
-  <mat-drawer-content><router-outlet></router-outlet></mat-drawer-content>
-</mat-drawer-container>
+<div class="c-settings">
+  <div class="c-settings__menu"><sofie-settings-menu></sofie-settings-menu></div>
+  <div class="c-settings__content"><router-outlet></router-outlet></div>
+</div>

--- a/src/app/settings/components/settings/settings.component.scss
+++ b/src/app/settings/components/settings/settings.component.scss
@@ -1,4 +1,11 @@
 .c-settings {
   min-height: calc(100vh - 70px);
   border-top: 1px solid #fff;
+  display: flex;
+  &__content {
+    flex-grow: 1;
+  }
+  &__menu {
+    flex: 0 0 14rem;
+  }
 }

--- a/src/app/settings/components/settings/settings.component.scss
+++ b/src/app/settings/components/settings/settings.component.scss
@@ -1,0 +1,4 @@
+.c-settings {
+  min-height: calc(100vh - 70px);
+  border-top: 1px solid #fff;
+}

--- a/src/app/settings/components/settings/settings.component.spec.ts
+++ b/src/app/settings/components/settings/settings.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { SettingsComponent } from './settings.component'
+
+describe('SettingsComponent', () => {
+  it('should create', async () => {
+    const component = await configureTestBed()
+    expect(component).toBeTruthy()
+  })
+})
+
+async function configureTestBed(): Promise<SettingsComponent> {
+  await TestBed.configureTestingModule({
+    providers: [],
+    declarations: [SettingsComponent],
+  }).compileComponents()
+
+  const fixture: ComponentFixture<SettingsComponent> = TestBed.createComponent(SettingsComponent)
+  return fixture.componentInstance
+}

--- a/src/app/settings/components/settings/settings.component.ts
+++ b/src/app/settings/components/settings/settings.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss'],
+})
+export class SettingsComponent {}

--- a/src/app/settings/settings-routing.module.ts
+++ b/src/app/settings/settings-routing.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core'
+import { RouterModule, Routes } from '@angular/router'
+import { SettingsComponent } from './components/settings/settings.component'
+import { ClearCacheComponent } from './components/clear-cache/clear-cache.component'
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SettingsComponent,
+    children: [
+      { path: '', redirectTo: 'action-triggers', pathMatch: 'full' },
+      { path: 'action-triggers', loadChildren: () => import('./action-triggers/action-triggers.module').then(module => module.ActionTriggersModule) },
+      { path: 'clear-cache', component: ClearCacheComponent },
+    ],
+  },
+]
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SettingsRoutingModule {}

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core'
+import { SharedModule } from '../shared/shared.module'
+import { SettingsRoutingModule } from './settings-routing.module'
+import { SettingsComponent } from './components/settings/settings.component'
+import { SettingsMenuComponent } from './components/settings/settings-menu/settings-menu.component'
+import { MatSidenavModule } from '@angular/material/sidenav'
+import { MatToolbarModule } from '@angular/material/toolbar'
+import { MatListModule } from '@angular/material/list'
+import { ClearCacheComponent } from './components/clear-cache/clear-cache.component'
+
+@NgModule({
+  declarations: [SettingsComponent, SettingsMenuComponent, ClearCacheComponent],
+  imports: [SettingsRoutingModule, SharedModule, MatSidenavModule, MatToolbarModule, MatListModule],
+})
+export class SettingsModule {}

--- a/src/app/shared/abstractions/action-trigger-parser.service.ts
+++ b/src/app/shared/abstractions/action-trigger-parser.service.ts
@@ -1,7 +1,6 @@
-import { ActionTrigger } from '../models/action-trigger'
+import { ActionTrigger, KeyboardTriggerData } from '../models/action-trigger'
 
 // TODO: This is technically just a validator and should be named as such, but we would need to agree to change the convention to that
 export abstract class ActionTriggerParser {
-  public abstract parseActionTrigger(actionTrigger: ActionTrigger): ActionTrigger
-  public abstract parseActionTriggers(actionTriggers: ActionTrigger[]): ActionTrigger[]
+  public abstract parseActionTriggers(actionTriggers: ActionTrigger<KeyboardTriggerData>[]): ActionTrigger<KeyboardTriggerData>[]
 }

--- a/src/app/shared/abstractions/action-trigger.service.ts
+++ b/src/app/shared/abstractions/action-trigger.service.ts
@@ -1,6 +1,9 @@
 import { Observable } from 'rxjs'
-import { ActionTrigger } from '../models/action-trigger'
+import { ActionTrigger, EditActionsTriggers, KeyboardTriggerData } from '../models/action-trigger'
 
 export abstract class ActionTriggerService {
-  public abstract getActionTriggers(): Observable<ActionTrigger[]>
+  public abstract getActionTriggers(): Observable<ActionTrigger<KeyboardTriggerData>[]>
+  public abstract createActionTrigger(actionTrigger: EditActionsTriggers): Observable<void>
+  public abstract updateActionTrigger(actionTrigger: EditActionsTriggers): Observable<void>
+  public abstract deleteActionTrigger(actionTriggerId: string): Observable<void>
 }

--- a/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, HostBinding, Inject } from '@angular/core'
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog'
 import { StronglyTypedDialog } from '../../directives/strongly-typed-dialog.directive'
 import { ThemePalette } from '@angular/material/core'
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog'
 
 export enum DialogSeverity {
   INFO = 'INFO',

--- a/src/app/shared/components/dropdown-button/dropdown-button.component.html
+++ b/src/app/shared/components/dropdown-button/dropdown-button.component.html
@@ -1,0 +1,14 @@
+<button class="custom-dropdown-button" mat-button [matMenuTriggerFor]="dropdownMenu">
+  <fa-icon [icon]="iconButtonProp" [size]="iconButtonSizeProp"></fa-icon>
+  <span class="custom-dropdown-button__label" *ngIf="!!label">{{ label }}</span>
+</button>
+<mat-menu class="custom-dropdown_menu" #dropdownMenu="matMenu">
+  <button
+    *ngFor="let option of options"
+    [ngClass]="{ 'custom-dropdown_menu__selected': option.key === selected }"
+    [disabled]="option.disabled ? option.disabled : false"
+    mat-menu-item
+    (click)="selectOption(option)">
+    {{ option.label }}
+  </button>
+</mat-menu>

--- a/src/app/shared/components/dropdown-button/dropdown-button.component.scss
+++ b/src/app/shared/components/dropdown-button/dropdown-button.component.scss
@@ -1,0 +1,12 @@
+.custom-dropdown-button {
+  &__label {
+    display: inline;
+    margin-left: 0.5rem;
+  }
+}
+
+.custom-dropdown_menu {
+  &__selected {
+    font-weight: 700;
+  }
+}

--- a/src/app/shared/components/dropdown-button/dropdown-button.component.spec.ts
+++ b/src/app/shared/components/dropdown-button/dropdown-button.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { DropdownButtonComponent } from './dropdown-button.component'
+import { MatMenuModule } from '@angular/material/menu'
+
+describe('DropdownButtonComponent', () => {
+  let component: DropdownButtonComponent
+  let fixture: ComponentFixture<DropdownButtonComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DropdownButtonComponent],
+      imports: [MatMenuModule],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(DropdownButtonComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/shared/components/dropdown-button/dropdown-button.component.ts
+++ b/src/app/shared/components/dropdown-button/dropdown-button.component.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
+import { IconProp, SizeProp } from '@fortawesome/fontawesome-svg-core'
+import { IconButton, IconButtonSize } from '../../enums/icon-button'
+import { IconsUtil } from 'src/app/helper/icons.util'
+
+export interface SofieDroppdownOptions {
+  label: string
+  key: string
+  disabled?: boolean
+}
+
+@Component({
+  selector: 'sofie-dropdown-button',
+  templateUrl: './dropdown-button.component.html',
+  styleUrls: ['./dropdown-button.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DropdownButtonComponent implements OnInit {
+  @Input() public iconButtonSize: IconButtonSize
+  @Input() public iconButton: IconButton
+  @Input() public label: string = ''
+  @Input() public selected: string = ''
+  @Input() public options: SofieDroppdownOptions[]
+  @Output() private readonly optionSelect: EventEmitter<string> = new EventEmitter<string>()
+
+  public iconButtonSizeProp: SizeProp
+  public iconButtonProp: IconProp
+
+  public ngOnInit(): void {
+    this.iconButtonProp = IconsUtil.getIconProperty(this.iconButton)
+    this.iconButtonSizeProp = IconsUtil.getIconSizeProperty(this.iconButtonSize ?? IconButtonSize.M)
+  }
+
+  public selectOption(option: SofieDroppdownOptions): void {
+    this.optionSelect.emit(option.key)
+  }
+}

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -8,6 +8,8 @@
       <a class="c-header__nav-item" (click)="navigateToRundown()" i18n>header-component.rundowns.label</a>
       <a class="c-header__nav-item" (click)="navigateToStatus()" i18n>header-component.status.label</a>
     </mat-nav-list>
+    <mat-nav-list>
+      <a class="c-header__nav-item" (click)="navigateToSettings()" i18n>rundown-overview.settings.title</a>
+    </mat-nav-list>
   </mat-toolbar-row>
 </mat-toolbar>
-

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -33,4 +33,9 @@ export class HeaderComponent {
     const segmentedPath: string[] = [Paths.STATUS]
     this.router.navigate(segmentedPath).catch(error => this.logger.data(error).warn(`Failed navigating to /${segmentedPath.join('/')}.`))
   }
+
+  public navigateToSettings(): void {
+    const segmentedPath: string[] = [Paths.SETTINGS]
+    this.router.navigate(segmentedPath).catch(error => this.logger.data(error).warn(`Failed navigating to /${segmentedPath.join('/')}.`))
+  }
 }

--- a/src/app/shared/components/icon-button/icon-button.component.ts
+++ b/src/app/shared/components/icon-button/icon-button.component.ts
@@ -1,7 +1,7 @@
 import { Component, HostBinding, Input, OnInit } from '@angular/core'
 import { IconProp, SizeProp } from '@fortawesome/fontawesome-svg-core'
 import { IconButton, IconButtonSize } from '../../enums/icon-button'
-import { faTrashCan, faXmark, faBars, faPlus, faMinus, faArrowsH } from '@fortawesome/free-solid-svg-icons'
+import { IconsUtil } from 'src/app/helper/icons.util'
 
 @Component({
   selector: 'sofie-icon-button',
@@ -23,45 +23,7 @@ export class IconButtonComponent implements OnInit {
   public iconButtonSizeProp: SizeProp
 
   public ngOnInit(): void {
-    this.iconButtonProp = this.getIconProperty(this.iconButton)
-    this.iconButtonSizeProp = this.getIconSizeProperty(this.iconButtonSize ?? IconButtonSize.M)
-  }
-
-  public getIconProperty(iconButton: IconButton): IconProp {
-    switch (iconButton) {
-      case IconButton.XMARK:
-        return faXmark
-      case IconButton.TRASH_CAN:
-        return faTrashCan
-      case IconButton.BARS:
-        return faBars
-      case IconButton.PLUS:
-        return faPlus
-      case IconButton.MINUS:
-        return faMinus
-      case IconButton.HORIZONTAL_ARROWS:
-        return faArrowsH
-      default:
-        return faXmark
-    }
-  }
-
-  public getIconSizeProperty(iconButtonSize: IconButtonSize): SizeProp {
-    switch (iconButtonSize) {
-      case IconButtonSize.XS:
-        return 'xs'
-      case IconButtonSize.S:
-        return 'sm'
-      case IconButtonSize.M:
-        return '1x'
-      case IconButtonSize.L:
-        return 'lg'
-      case IconButtonSize.XL:
-        return 'xl'
-      case IconButtonSize.XXL:
-        return '2xl'
-      default:
-        return '1x'
-    }
+    this.iconButtonProp = IconsUtil.getIconProperty(this.iconButton)
+    this.iconButtonSizeProp = IconsUtil.getIconSizeProperty(this.iconButtonSize ?? IconButtonSize.M)
   }
 }

--- a/src/app/shared/components/icon-checkbox/custom-checkbox.component.html
+++ b/src/app/shared/components/icon-checkbox/custom-checkbox.component.html
@@ -1,0 +1,6 @@
+<div class="sofie-form-check">
+  <input type="checkbox" class="sofie-form-check__input" [id]="checkboxId" [(ngModel)]="selected" [readonly]="disabled" (click)="checkboxClick()" />
+  <label class="sofie-form-check__label" [for]="checkboxId">
+    <span *ngIf="label">{{ label }}</span>
+  </label>
+</div>

--- a/src/app/shared/components/icon-checkbox/custom-checkbox.component.scss
+++ b/src/app/shared/components/icon-checkbox/custom-checkbox.component.scss
@@ -1,0 +1,12 @@
+.custom-dropdown-button {
+  &__label {
+    display: inline;
+    margin-left: 0.5rem;
+  }
+}
+
+.custom-dropdown_menu {
+  &__selected {
+    font-weight: 700;
+  }
+}

--- a/src/app/shared/components/icon-checkbox/custom-checkbox.component.spec.ts
+++ b/src/app/shared/components/icon-checkbox/custom-checkbox.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { CustomCheckboxComponent } from './custom-checkbox.component'
+
+describe('CustomCheckboxComponent', () => {
+  let component: CustomCheckboxComponent
+  let fixture: ComponentFixture<CustomCheckboxComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CustomCheckboxComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(CustomCheckboxComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/shared/components/icon-checkbox/custom-checkbox.component.ts
+++ b/src/app/shared/components/icon-checkbox/custom-checkbox.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core'
+
+@Component({
+  selector: 'sofie-custom-checkbox',
+  templateUrl: './custom-checkbox.component.html',
+  styleUrls: ['./custom-checkbox.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomCheckboxComponent {
+  @Input() public label: string
+  @Input() public selected: boolean
+  @Input() public disabled: boolean
+  @Input() public checkboxId: string
+  @Output() private readonly checkboxChange: EventEmitter<boolean> = new EventEmitter<boolean>()
+
+  public checkboxClick(): void {
+    this.checkboxChange.emit(!this.selected)
+  }
+}

--- a/src/app/shared/components/loading/loading.component.scss
+++ b/src/app/shared/components/loading/loading.component.scss
@@ -1,0 +1,5 @@
+:host {
+  & .c-loader {
+    margin: 0 auto;
+  }
+}

--- a/src/app/shared/components/loading/loading.component.spec.ts
+++ b/src/app/shared/components/loading/loading.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { LoadingComponent } from './loading.component'
+
+describe('LoadingComponent', () => {
+  let component: LoadingComponent
+  let fixture: ComponentFixture<LoadingComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LoadingComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(LoadingComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/shared/components/loading/loading.component.ts
+++ b/src/app/shared/components/loading/loading.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+
+@Component({
+  selector: 'sofie-loading',
+  template: '<mat-spinner class="c-loader" [diameter]="40"></mat-spinner>',
+  styleUrls: ['./loading.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LoadingComponent {}

--- a/src/app/shared/enums/icon-button.ts
+++ b/src/app/shared/enums/icon-button.ts
@@ -5,6 +5,10 @@ export enum IconButton {
   PLUS = 'PLUS',
   MINUS = 'MINUS',
   HORIZONTAL_ARROWS = 'HORIZONTAL_ARROWS',
+  COPY = 'COPY',
+  SORT = 'SORT',
+  FILTER = 'FILTER',
+  SQUARE_CHECK = 'SQUARE_CHECK',
 }
 
 export enum IconButtonSize {

--- a/src/app/shared/models/action-trigger.ts
+++ b/src/app/shared/models/action-trigger.ts
@@ -3,3 +3,34 @@ export interface ActionTrigger<Data = unknown> {
   actionId: string
   data: Data
 }
+
+export interface KeyboardTriggerData {
+  keys: string[]
+  actionArguments?: unknown
+}
+
+export interface KeyboardAndSelectionTriggerData extends KeyboardTriggerData {
+  selected?: boolean
+}
+
+export interface EditActionsTriggers {
+  actionId: string
+  id?: string
+  data: {
+    keys: string[]
+    actionArguments?: number
+  }
+}
+
+export enum ActionTriggerSortKeys {
+  ACTION_ID_A_Z = 'ACTION_ID_A_Z',
+  ACTION_ID_Z_A = 'ACTION_ID_Z_A',
+  SHORTCUT_A_Z = 'SHORTCUT_A_Z',
+  SHORTCUT_Z_A = 'SHORTCUT_Z_A',
+}
+
+export enum UserActionsWithSelectedTriggers {
+  TOGGLE_SELECT = 'TOGGLE_SELECT',
+  EXPORT = 'EXPORT',
+  DELETE = 'DELETE',
+}

--- a/src/app/shared/services/http/http-action-trigger.service.ts
+++ b/src/app/shared/services/http/http-action-trigger.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core'
 import { catchError, map, Observable } from 'rxjs'
 import { ActionTriggerService } from '../../abstractions/action-trigger.service'
-import { ActionTrigger } from '../../models/action-trigger'
+import { ActionTrigger, EditActionsTriggers, KeyboardTriggerData } from '../../models/action-trigger'
 import { HttpClient } from '@angular/common/http'
 import { environment } from '../../../../environments/environment'
 import { ActionTriggerParser } from '../../abstractions/action-trigger-parser.service'
@@ -20,10 +20,22 @@ export class HttpActionTriggerService extends ActionTriggerService {
     super()
   }
 
-  public getActionTriggers(): Observable<ActionTrigger[]> {
-    return this.http.get<HttpResponse<ActionTrigger[]>>(ACTION_TRIGGER_URL).pipe(
+  public getActionTriggers(): Observable<ActionTrigger<KeyboardTriggerData>[]> {
+    return this.http.get<HttpResponse<ActionTrigger<KeyboardTriggerData>[]>>(`${environment.apiBaseUrl}/actionTriggers`).pipe(
       catchError(error => this.httpErrorService.catchError(error)),
       map(response => this.actionTriggerParser.parseActionTriggers(response.data))
     )
+  }
+
+  public createActionTrigger(actionTrigger: EditActionsTriggers): Observable<void> {
+    return this.http.post<void>(`${ACTION_TRIGGER_URL}`, actionTrigger)
+  }
+
+  public updateActionTrigger(actionTrigger: EditActionsTriggers): Observable<void> {
+    return this.http.put<void>(`${ACTION_TRIGGER_URL}`, actionTrigger)
+  }
+
+  public deleteActionTrigger(actionTriggerId: string): Observable<void> {
+    return this.http.delete<void>(`${ACTION_TRIGGER_URL}/${actionTriggerId}`)
   }
 }

--- a/src/app/shared/services/zod-action-trigger-parser.service.ts
+++ b/src/app/shared/services/zod-action-trigger-parser.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
 import { ActionTriggerParser } from '../abstractions/action-trigger-parser.service'
-import { ActionTrigger } from '../models/action-trigger'
+import { ActionTrigger, KeyboardTriggerData } from '../models/action-trigger'
 import * as zod from 'zod'
 
 @Injectable()
@@ -12,14 +12,15 @@ export class ZodActionTriggerParser extends ActionTriggerParser {
   private readonly zodActionTriggerParser = zod.object({
     id: zod.string().min(1),
     actionId: zod.string().min(1),
-    data: zod.object({}).passthrough(),
+    data: zod.object({
+      keys: zod.string().array(),
+      actionArguments: zod.number().or(zod.string().optional()).optional(),
+    }),
   })
 
-  public parseActionTrigger(actionTrigger: ActionTrigger): ActionTrigger {
-    return this.zodActionTriggerParser.parse(actionTrigger)
-  }
+  private readonly actionTriggersParser = this.zodActionTriggerParser.array()
 
-  public parseActionTriggers(actionTriggers: ActionTrigger[]): ActionTrigger[] {
-    return this.zodActionTriggerParser.array().parse(actionTriggers)
+  public parseActionTriggers(actionTriggers: ActionTrigger<KeyboardTriggerData>[]): ActionTrigger<KeyboardTriggerData>[] {
+    return this.actionTriggersParser.parse(actionTriggers)
   }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -43,6 +43,12 @@ import { HttpClientModule } from '@angular/common/http'
 import { HttpErrorService } from './services/http/http-error.service'
 import { Logger } from '../core/abstractions/logger.service'
 import { Tv2LoggerService } from '../core/services/tv2-logger.service'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { LoadingComponent } from './components/loading/loading.component'
+import { DropdownButtonComponent } from './components/dropdown-button/dropdown-button.component'
+import { MatMenuModule } from '@angular/material/menu'
+import { CustomCheckboxComponent } from './components/icon-checkbox/custom-checkbox.component'
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 
 @NgModule({
   declarations: [
@@ -58,6 +64,9 @@ import { Tv2LoggerService } from '../core/services/tv2-logger.service'
     Tv2ActionPanelComponent,
     Tv2ActionCardComponent,
     TimerPipe,
+    LoadingComponent,
+    DropdownButtonComponent,
+    CustomCheckboxComponent,
   ],
   imports: [
     CommonModule,
@@ -73,7 +82,11 @@ import { Tv2LoggerService } from '../core/services/tv2-logger.service'
     MatDialogModule,
     FontAwesomeModule,
     CdkMenuModule,
+    ReactiveFormsModule,
+    FormsModule,
     MatSelectModule,
+    MatProgressSpinnerModule,
+    MatMenuModule,
   ],
   exports: [
     CommonModule,
@@ -88,6 +101,11 @@ import { Tv2LoggerService } from '../core/services/tv2-logger.service'
     ContextMenuComponent,
     Tv2ActionPanelComponent,
     Tv2ActionCardComponent,
+    LoadingComponent,
+    DropdownButtonComponent,
+    CustomCheckboxComponent,
+    ReactiveFormsModule,
+    FormsModule,
   ],
   providers: [
     { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { duration: 5000, verticalPosition: 'top' } },

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -66,6 +66,18 @@
         <source>header-component.status.label</source>
         <target>Status</target>
       </trans-unit>
+      <trans-unit id="7774679192134693239" datatype="html">
+        <source>rundown-overview.settings.title</source>
+        <target state="new">Indstillinger</target>
+      </trans-unit>
+      <trans-unit id="212168824510245649" datatype="html">
+        <source>settings.action-triggers.label</source>
+        <target state="new">Action Triggers</target>
+      </trans-unit>
+      <trans-unit id="4380077604653787346" datatype="html">
+        <source>settings.clear-cache.label</source>
+        <target state="new">Ryd cache</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -78,6 +78,106 @@
         <source>settings.clear-cache.label</source>
         <target state="new">Ryd cache</target>
       </trans-unit>
+      <trans-unit id="363239608614074698" datatype="html">
+        <source>action-triggers.no-shortcuts.label</source>
+        <target state="new">No shortcuts found</target>
+      </trans-unit>
+      <trans-unit id="3982465886333434114" datatype="html">
+        <source>action-triggers.keyboard-shortcuts.label</source>
+        <target state="new">Keyboard shortcuts</target>
+      </trans-unit>
+      <trans-unit id="948302468790980101" datatype="html">
+        <source>action-triggers.create-shortcut.button</source>
+        <target state="new">Create shortcut</target>
+      </trans-unit>
+      <trans-unit id="8903207483897140758" datatype="html">
+        <source>action-triggers.export-shortcuts.button</source>
+        <target state="new">Export shortcuts</target>
+      </trans-unit>
+      <trans-unit id="5998298101573406065" datatype="html">
+        <source>action-triggers.import-shortcuts.button</source>
+        <target state="new">Import shortcuts</target>
+      </trans-unit>
+      <trans-unit id="7618983089240067205" datatype="html">
+        <source>action-triggers.shortcut.label</source>
+        <target state="new">Shortcut</target>
+      </trans-unit>
+      <trans-unit id="4236071901286997238" datatype="html">
+        <source>action-triggers.action-argument.label</source>
+        <target state="new">Action argument</target>
+      </trans-unit>
+      <trans-unit id="6452586448481444952" datatype="html">
+        <source>action-triggers.selected-action-id.label</source>
+        <target state="new">Selected action ID</target>
+      </trans-unit>
+      <trans-unit id="8600924712017711472" datatype="html">
+        <source>global.cancel.button</source>
+        <target state="new">Cancel</target>
+      </trans-unit>
+      <trans-unit id="5071145978603597350" datatype="html">
+        <source>global.save.button</source>
+        <target state="new">Save</target>
+      </trans-unit>
+      <trans-unit id="946249916134408794" datatype="html">
+        <source>action-triggers.no-actions.label</source>
+        <target state="new">No actions found</target>
+      </trans-unit>
+      <trans-unit id="5494360365717860632" datatype="html">
+        <source>action-triggers.update-shortcut.title</source>
+        <target state="new">Update keyboard shortcut</target>
+      </trans-unit>
+      <trans-unit id="3296269694384339031" datatype="html">
+        <source>action-triggers.create-shortcut.title</source>
+        <target state="new">Create new keyboard shortcut</target>
+      </trans-unit>
+      <trans-unit id="8226341358716533598" datatype="html">
+        <source>action-triggers-sort.action-id-a-z.label</source>
+        <target state="new">Action ID A -&gt; Z</target>
+      </trans-unit>
+      <trans-unit id="2372225858869981312" datatype="html">
+        <source>action-triggers-sort.action-id-z-a.label</source>
+        <target state="new">Action ID Z -&gt; A</target>
+      </trans-unit>
+      <trans-unit id="7501524180811696949" datatype="html">
+        <source>action-triggers-sort.shortcut-a-z.label</source>
+        <target state="new">Shortcut A -&gt; Z</target>
+      </trans-unit>
+      <trans-unit id="4507516233891515823" datatype="html">
+        <source>action-triggers-sort.shortcut-z-a.label</source>
+        <target state="new">Shortcut Z -&gt; A</target>
+      </trans-unit>
+      <trans-unit id="8924063720972378650" datatype="html">
+        <source>global.sort.label</source>
+        <target state="new">Sort</target>
+      </trans-unit>
+      <trans-unit id="556928192640127224" datatype="html">
+        <source>action-triggers-sort.export-selected.label</source>
+        <target state="new">Export selected</target>
+      </trans-unit>
+      <trans-unit id="7386626478307143738" datatype="html">
+        <source>action-triggers.delete-selected.label</source>
+        <target state="new">Delete selected</target>
+      </trans-unit>
+      <trans-unit id="1532790028301204513" datatype="html">
+        <source>global.delete.label</source>
+        <target state="new">Delete</target>
+      </trans-unit>
+      <trans-unit id="5133358426840332221" datatype="html">
+        <source>action-triggers.delete.confirmation</source>
+        <target state="new">Are you sure you want to delete this action trigger?</target>
+      </trans-unit>
+      <trans-unit id="1543520618037329297" datatype="html">
+        <source>action-triggers.delete-selected.confirmation</source>
+        <target state="new">Are you sure you want to delete all selected action triggers?</target>
+      </trans-unit>
+      <trans-unit id="4054896224656862418" datatype="html">
+        <source>global.select-all.label</source>
+        <target state="new">Select All</target>
+      </trans-unit>
+      <trans-unit id="4978684078154973195" datatype="html">
+        <source>global.unselect-all.label</source>
+        <target state="new">Unselect all</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.en-US.xlf
+++ b/src/locale/messages.en-US.xlf
@@ -66,6 +66,18 @@
         <source>header-component.status.label</source>
         <target>Status</target>
       </trans-unit>
+      <trans-unit id="7774679192134693239" datatype="html">
+        <source>rundown-overview.settings.title</source>
+        <target state="new">Settings</target>
+      </trans-unit>
+      <trans-unit id="212168824510245649" datatype="html">
+        <source>settings.action-triggers.label</source>
+        <target state="new">Action triggers</target>
+      </trans-unit>
+      <trans-unit id="4380077604653787346" datatype="html">
+        <source>settings.clear-cache.label</source>
+        <target state="new">Clear cache</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.en-US.xlf
+++ b/src/locale/messages.en-US.xlf
@@ -78,6 +78,106 @@
         <source>settings.clear-cache.label</source>
         <target state="new">Clear cache</target>
       </trans-unit>
+      <trans-unit id="363239608614074698" datatype="html">
+        <source>action-triggers.no-shortcuts.label</source>
+        <target state="new">No shortcuts found</target>
+      </trans-unit>
+      <trans-unit id="3982465886333434114" datatype="html">
+        <source>action-triggers.keyboard-shortcuts.label</source>
+        <target state="new">Keyboard shortcuts</target>
+      </trans-unit>
+      <trans-unit id="948302468790980101" datatype="html">
+        <source>action-triggers.create-shortcut.button</source>
+        <target state="new">Create shortcut</target>
+      </trans-unit>
+      <trans-unit id="8903207483897140758" datatype="html">
+        <source>action-triggers.export-shortcuts.button</source>
+        <target state="new">Export shortcuts</target>
+      </trans-unit>
+      <trans-unit id="5998298101573406065" datatype="html">
+        <source>action-triggers.import-shortcuts.button</source>
+        <target state="new">Import shortcuts</target>
+      </trans-unit>
+      <trans-unit id="7618983089240067205" datatype="html">
+        <source>action-triggers.shortcut.label</source>
+        <target state="new">Shortcut</target>
+      </trans-unit>
+      <trans-unit id="4236071901286997238" datatype="html">
+        <source>action-triggers.action-argument.label</source>
+        <target state="new">Action argument</target>
+      </trans-unit>
+      <trans-unit id="6452586448481444952" datatype="html">
+        <source>action-triggers.selected-action-id.label</source>
+        <target state="new">Selected action ID</target>
+      </trans-unit>
+      <trans-unit id="8600924712017711472" datatype="html">
+        <source>global.cancel.button</source>
+        <target state="new">Cancel</target>
+      </trans-unit>
+      <trans-unit id="5071145978603597350" datatype="html">
+        <source>global.save.button</source>
+        <target state="new">Save</target>
+      </trans-unit>
+      <trans-unit id="946249916134408794" datatype="html">
+        <source>action-triggers.no-actions.label</source>
+        <target state="new">No actions found</target>
+      </trans-unit>
+      <trans-unit id="5494360365717860632" datatype="html">
+        <source>action-triggers.update-shortcut.title</source>
+        <target state="new">Update keyboard shortcut</target>
+      </trans-unit>
+      <trans-unit id="3296269694384339031" datatype="html">
+        <source>action-triggers.create-shortcut.title</source>
+        <target state="new">Create new keyboard shortcut</target>
+      </trans-unit>
+      <trans-unit id="8226341358716533598" datatype="html">
+        <source>action-triggers-sort.action-id-a-z.label</source>
+        <target state="new">Action ID (A -&gt; Z)</target>
+      </trans-unit>
+      <trans-unit id="2372225858869981312" datatype="html">
+        <source>action-triggers-sort.action-id-z-a.label</source>
+        <target state="new">Action ID (Z -&gt; A)</target>
+      </trans-unit>
+      <trans-unit id="7501524180811696949" datatype="html">
+        <source>action-triggers-sort.shortcut-a-z.label</source>
+        <target state="new">Shortcut (A -&gt; Z)</target>
+      </trans-unit>
+      <trans-unit id="4507516233891515823" datatype="html">
+        <source>action-triggers-sort.shortcut-z-a.label</source>
+        <target state="new">Shortcut (Z -&gt; A)</target>
+      </trans-unit>
+      <trans-unit id="8924063720972378650" datatype="html">
+        <source>global.sort.label</source>
+        <target state="new">Sort</target>
+      </trans-unit>
+      <trans-unit id="556928192640127224" datatype="html">
+        <source>action-triggers-sort.export-selected.label</source>
+        <target state="new">Export selected</target>
+      </trans-unit>
+      <trans-unit id="7386626478307143738" datatype="html">
+        <source>action-triggers.delete-selected.label</source>
+        <target state="new">Delete selected</target>
+      </trans-unit>
+      <trans-unit id="1532790028301204513" datatype="html">
+        <source>global.delete.label</source>
+        <target state="new">Delete</target>
+      </trans-unit>
+      <trans-unit id="5133358426840332221" datatype="html">
+        <source>action-triggers.delete.confirmation</source>
+        <target state="new">Are you sure you want to delete this action trigger?</target>
+      </trans-unit>
+      <trans-unit id="1543520618037329297" datatype="html">
+        <source>action-triggers.delete-selected.confirmation</source>
+        <target state="new">Are you sure you want to delete all selected action triggers?</target>
+      </trans-unit>
+      <trans-unit id="4054896224656862418" datatype="html">
+        <source>global.select-all.label</source>
+        <target state="new">Select All</target>
+      </trans-unit>
+      <trans-unit id="4978684078154973195" datatype="html">
+        <source>global.unselect-all.label</source>
+        <target state="new">Unselect all</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -59,6 +59,81 @@
       <trans-unit id="4380077604653787346" datatype="html">
         <source>settings.clear-cache.label</source>
       </trans-unit>
+      <trans-unit id="363239608614074698" datatype="html">
+        <source>action-triggers.no-shortcuts.label</source>
+      </trans-unit>
+      <trans-unit id="3982465886333434114" datatype="html">
+        <source>action-triggers.keyboard-shortcuts.label</source>
+      </trans-unit>
+      <trans-unit id="4236071901286997238" datatype="html">
+        <source>action-triggers.action-argument.label</source>
+      </trans-unit>
+      <trans-unit id="5071145978603597350" datatype="html">
+        <source>global.save.button</source>
+      </trans-unit>
+      <trans-unit id="5998298101573406065" datatype="html">
+        <source>action-triggers.import-shortcuts.button</source>
+      </trans-unit>
+      <trans-unit id="6452586448481444952" datatype="html">
+        <source>action-triggers.selected-action-id.label</source>
+      </trans-unit>
+      <trans-unit id="7618983089240067205" datatype="html">
+        <source>action-triggers.shortcut.label</source>
+      </trans-unit>
+      <trans-unit id="8600924712017711472" datatype="html">
+        <source>global.cancel.button</source>
+      </trans-unit>
+      <trans-unit id="8903207483897140758" datatype="html">
+        <source>action-triggers.export-shortcuts.button</source>
+      </trans-unit>
+      <trans-unit id="946249916134408794" datatype="html">
+        <source>action-triggers.no-actions.label</source>
+      </trans-unit>
+      <trans-unit id="948302468790980101" datatype="html">
+        <source>action-triggers.create-shortcut.button</source>
+      </trans-unit>
+      <trans-unit id="3296269694384339031" datatype="html">
+        <source>action-triggers.create-shortcut.title</source>
+      </trans-unit>
+      <trans-unit id="5494360365717860632" datatype="html">
+        <source>action-triggers.update-shortcut.title</source>
+      </trans-unit>
+      <trans-unit id="2372225858869981312" datatype="html">
+        <source>action-triggers-sort.action-id-z-a.label</source>
+      </trans-unit>
+      <trans-unit id="4507516233891515823" datatype="html">
+        <source>action-triggers-sort.shortcut-z-a.label</source>
+      </trans-unit>
+      <trans-unit id="7501524180811696949" datatype="html">
+        <source>action-triggers-sort.shortcut-a-z.label</source>
+      </trans-unit>
+      <trans-unit id="8226341358716533598" datatype="html">
+        <source>action-triggers-sort.action-id-a-z.label</source>
+      </trans-unit>
+      <trans-unit id="8924063720972378650" datatype="html">
+        <source>global.sort.label</source>
+      </trans-unit>
+      <trans-unit id="556928192640127224" datatype="html">
+        <source>action-triggers-sort.export-selected.label</source>
+      </trans-unit>
+      <trans-unit id="7386626478307143738" datatype="html">
+        <source>action-triggers.delete-selected.label</source>
+      </trans-unit>
+      <trans-unit id="1532790028301204513" datatype="html">
+        <source>global.delete.label</source>
+      </trans-unit>
+      <trans-unit id="1543520618037329297" datatype="html">
+        <source>action-triggers.delete-selected.confirmation</source>
+      </trans-unit>
+      <trans-unit id="5133358426840332221" datatype="html">
+        <source>action-triggers.delete.confirmation</source>
+      </trans-unit>
+      <trans-unit id="4054896224656862418" datatype="html">
+        <source>global.select-all.label</source>
+      </trans-unit>
+      <trans-unit id="4978684078154973195" datatype="html">
+        <source>global.unselect-all.label</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -50,6 +50,15 @@
       <trans-unit id="9014307158606167673" datatype="html">
         <source>header-component.status.label</source>
       </trans-unit>
+      <trans-unit id="7774679192134693239" datatype="html">
+        <source>rundown-overview.settings.title</source>
+      </trans-unit>
+      <trans-unit id="212168824510245649" datatype="html">
+        <source>settings.action-triggers.label</source>
+      </trans-unit>
+      <trans-unit id="4380077604653787346" datatype="html">
+        <source>settings.clear-cache.label</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/scss/_sofie-colors.scss
+++ b/src/scss/_sofie-colors.scss
@@ -1,0 +1,31 @@
+.camera_color {
+  background-color: $sofie-camera-color;
+  color: #fff;
+}
+.remote_color {
+  background-color: $sofie-remote-color;
+  color: #fff;
+}
+.video_clip_color {
+  background-color: $sofie-video-clip-color;
+  color: #fff;
+}
+.transition_color {
+  background-color: $sofie-transition-color;
+  color: #fff;
+}
+.graphics_color {
+  background-color: $sofie-graphics-color;
+}
+.audio_color {
+  background-color: $sofie-audio-color;
+  color: #fff;
+}
+.split_screen_color {
+  background: $sofie-split-screen-gradient;
+  color: #fff;
+}
+.replay_color {
+  background: $sofie-replay-color;
+  color: #fff;
+}

--- a/src/scss/_sofie-forms.scss
+++ b/src/scss/_sofie-forms.scss
@@ -1,0 +1,65 @@
+.text-center {
+  text-align: center;
+}
+
+input,
+select {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  border: 1px solid $sofie-gray;
+}
+
+.c-sofie-control-error {
+  & input {
+    border-color: $sofie-danger;
+  }
+}
+
+.sofie-form-check {
+  display: inline-block;
+  position: relative;
+  padding-left: 25px;
+  margin-bottom: 18px;
+  cursor: pointer;
+  font-size: 22px;
+  user-select: none;
+  &__input {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 0;
+    width: 0;
+  }
+  &__label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 25px;
+    width: 25px;
+    background-color: #eee;
+    border-radius: 4px;
+    border: 1px solid $sofie-gray;
+    cursor: pointer;
+    &:after {
+      content: '';
+      position: absolute;
+      display: none;
+      left: 8px;
+      top: 3px;
+      width: 5px;
+      height: 10px;
+      border: solid white;
+      border-width: 0 3px 3px 0;
+      transform: rotate(45deg);
+    }
+  }
+  &:hover input ~ label {
+    background-color: #ccc;
+  }
+  & input:checked ~ label {
+    background-color: $sofie-primary;
+  }
+  & input:checked ~ label:after {
+    display: block;
+  }
+}

--- a/src/scss/_sofie-page.scss
+++ b/src/scss/_sofie-page.scss
@@ -1,0 +1,50 @@
+.c-sofie-button {
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 2rem;
+  border: 0;
+  cursor: pointer;
+  &.c-sofie-button-primary {
+    color: #fff;
+    background-color: $sofie-primary;
+    &:hover {
+      filter: brightness(90%);
+    }
+  }
+  &.c-sofie-button-gray {
+    color: #fff;
+    background-color: $sofie-dark;
+    &:hover {
+      filter: brightness(90%);
+    }
+  }
+}
+
+.c-sofie-card {
+  padding: 0.5rem;
+  display: block;
+  position: relative;
+  border-radius: 4px;
+  border: 1px solid $sofie-gray;
+  box-shadow:
+    0px 2px 1px -1px rgba(0, 0, 0, 0.2),
+    0px 1px 1px 0px rgba(0, 0, 0, 0.14),
+    0px 1px 3px 0px rgba(0, 0, 0, 0.12);
+  &.c-sofie-card-selected {
+    background-color: $sofie-gray;
+  }
+}
+
+.c-sofie-form-control {
+  display: block;
+  margin-bottom: 1rem;
+  & label {
+    display: block;
+    margin-bottom: 0.3rem;
+  }
+  & input {
+    display: block;
+    width: 100%;
+    font-size: 1rem;
+  }
+}

--- a/src/scss/_sofie-snack-bar.scss
+++ b/src/scss/_sofie-snack-bar.scss
@@ -1,0 +1,26 @@
+.snackbar-danger {
+  background: $sofie-danger;
+  color: white;
+
+  .mat-button-wrapper {
+    color: orangered;
+  }
+}
+
+.snackbar-warning {
+  background: yellow;
+  color: black;
+
+  .mat-button-wrapper {
+    color: black;
+  }
+}
+
+.snackbar-success {
+  background: green;
+  color: white;
+
+  .mat-button-wrapper {
+    color: white;
+  }
+}

--- a/src/scss/_sofie-vars.scss
+++ b/src/scss/_sofie-vars.scss
@@ -1,0 +1,15 @@
+$sofie-primary: #1f9ac7;
+$sofie-danger: #df0606;
+$sofie-white: #ffffff;
+$sofie-black: #000000;
+$sofie-gray: #d3d3d3;
+$sofie-dark: #464646;
+
+$sofie-camera-color: #005919;
+$sofie-remote-color: #ac29a5;
+$sofie-video-clip-color: #1769ff;
+$sofie-transition-color: #1a7a42;
+$sofie-graphics-color: #ca9d00;
+$sofie-audio-color: #9e0358;
+$sofie-split-screen-gradient: linear-gradient(to bottom, #00a99c 0%, #00a99c 50%, #265753 50%, #265753 100%);
+$sofie-replay-color: #8d1010;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,11 +1,17 @@
 /* You can add global styles to this file, and also import other style files */
-@import "./palettes.scss";
+@import './scss/sofie-vars';
+@import './scss/sofie-colors';
+@import './scss/sofie-page';
+@import './scss/sofie-forms';
+@import './scss/sofie-snack-bar';
+@import './palettes.scss';
 
 * {
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   height: 100%;
   overflow: hidden;
 }
@@ -14,31 +20,4 @@ body {
   margin: 0;
   font-family: Roboto, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
-}
-
-.snackbar-danger {
-  background: red;
-  color: white;
-
-  .mat-button-wrapper {
-    color: orangered;
-  }
-}
-
-.snackbar-warning {
-  background: yellow;
-  color: black;
-
-  .mat-button-wrapper {
-    color: black;
-  }
-}
-
-.snackbar-success {
-  background: green;
-  color: white;
-
-  .mat-button-wrapper {
-    color: white;
-  }
 }


### PR DESCRIPTION
- added much of the logic related to actions triggers
- adding new logic related to loading split SCSS files with adding vars file 
- fix all Init tests, but there are no tests related to the functionality itself. They will be added in the next commit
- change interface KeyboardTriggerData => keys => from [string, ...string[]] ==>to string[], so that it is more generalized and can be used in the new logic (Can be discussed)
- ActionArguments type logic is missing, will be added in next commit
