### PR TITLE
Sof 1744/hide empty segments

### DIFF
--- a/src/app/core/models/segment.ts
+++ b/src/app/core/models/segment.ts
@@ -10,6 +10,7 @@ export interface Segment {
   readonly isUnsynced: boolean
   readonly parts: Part[]
   readonly rank: number
+  readonly isHidden: boolean
   readonly expectedDurationInMs?: number
   readonly executedAtEpochTime?: number
 }

--- a/src/app/core/parsers/zod-entity-parser.service.ts
+++ b/src/app/core/parsers/zod-entity-parser.service.ts
@@ -81,7 +81,7 @@ export class ZodEntityParser implements EntityParser {
   private readonly segmentParser = zod.object({
     id: zod.string().min(1),
     rundownId: zod.string().min(1),
-    name: zod.string().min(1),
+    name: zod.string(),
     isOnAir: zod.boolean(),
     isNext: zod.boolean(),
     isUntimed: zod.boolean(),

--- a/src/app/core/parsers/zod-entity-parser.service.ts
+++ b/src/app/core/parsers/zod-entity-parser.service.ts
@@ -88,6 +88,7 @@ export class ZodEntityParser implements EntityParser {
     isUnsynced: zod.boolean(),
     parts: this.partParser.array(),
     rank: zod.number(),
+    isHidden: zod.boolean(),
     expectedDurationInMs: zod.number().optional(),
     executedAtEpochTime: zod.number().optional(),
   })

--- a/src/app/rundown-view/components/rundown/rundown.component.html
+++ b/src/app/rundown-view/components/rundown/rundown.component.html
@@ -1,10 +1,12 @@
 <div class="segments">
-    <sofie-segment
-        *ngFor="let segment of rundown?.segments; trackBy: trackSegment"
-        [segment]="segment"
-        [isRundownActive]="rundown ? rundown.isActive : false"
-        [durationInMsUntilSegmentIsPutOnAir]="startOffsetsInMsFromPlayheadForSegments[segment.id]"
-        [remainingDurationInMsForOnAirPart]="remainingDurationInMsForOnAirPart"
-        [currentEpochTime]="currentEpochTime"
-    ></sofie-segment>
+    <ng-container *ngFor="let segment of rundown?.segments; trackBy: trackSegment">
+        <sofie-segment
+                *ngIf="!segment.isHidden"
+                [segment]="segment"
+                [isRundownActive]="rundown ? rundown.isActive : false"
+                [durationInMsUntilSegmentIsPutOnAir]="startOffsetsInMsFromPlayheadForSegments[segment.id]"
+                [remainingDurationInMsForOnAirPart]="remainingDurationInMsForOnAirPart"
+                [currentEpochTime]="currentEpochTime"
+        ></sofie-segment>
+    </ng-container>
 </div>

--- a/src/app/test/factories/test-entity.factory.ts
+++ b/src/app/test/factories/test-entity.factory.ts
@@ -30,6 +30,7 @@ export class TestEntityFactory {
       isOnAir: false,
       isUntimed: false,
       isUnsynced: false,
+      isHidden: false,
       parts: [],
       ...segment,
     }


### PR DESCRIPTION
All dependent PRs have been merged

- Segments that are hidden are no longer shown
- Segments that have no title nor any Parts/Pieces are no longer shown
- Segments that have no title, but have Parts/Pieces are shown without a title
- Segments that have a title, but no Parts/Pieces are no longer shown