### PR TITLE
Fix: Draggable shelf remembers position if dragged past window bottom

### DIFF
--- a/src/app/shared/components/draggable-shelf/draggable-shelf.component.ts
+++ b/src/app/shared/components/draggable-shelf/draggable-shelf.component.ts
@@ -93,7 +93,7 @@ export class DraggableShelfComponent implements OnInit {
     if (this.verticalDragPositionFromDragHandleBottomInPixels === undefined) {
       return
     }
-    this.heightInPixels = window.innerHeight - event.clientY + this.verticalDragPositionFromDragHandleBottomInPixels
+    this.heightInPixels = Math.max(0, window.innerHeight - event.clientY + this.verticalDragPositionFromDragHandleBottomInPixels)
   }
 
   protected toggleCollapse(): void {


### PR DESCRIPTION
The draggable shelf had an issue, where the height could be set to a negative amount of pixels (from dragging it past the window bottom), which would make it fill up most of the screen, when the rundown view was reloaded.
To fix this, the height value has been given a lower cap of `0px`.