### PR TITLE
SOF-1686 Add Robot ActionContentType

### DIFF
--- a/src/app/shared/models/tv2-action.ts
+++ b/src/app/shared/models/tv2-action.ts
@@ -22,6 +22,7 @@ export enum Tv2ActionContentType {
   AUDIO = 'AUDIO',
   SPLIT_SCREEN = 'SPLIT_SCREEN',
   REPLAY = 'REPLAY',
+  ROBOT = 'ROBOT',
   UNKNOWN = 'UNKNOWN',
 }
 


### PR DESCRIPTION
In order to load RobotActions in the frontend, the frontend needs to know that the Robot ActionType exists.