### PR TITLE
SOF-1810 - update pieces on RundownInfinitePiecesUpdated (re)

### DIFF
--- a/src/app/core/services/models/rundown-entity.service.ts
+++ b/src/app/core/services/models/rundown-entity.service.ts
@@ -165,8 +165,8 @@ export class RundownEntityService {
     if (segmentForPartIndex < 0) {
       return rundown
     }
-    const partToUpdateIndex: number | undefined = rundown.segments[segmentForPartIndex].parts.findIndex(existingPart => part.segmentId.startsWith(existingPart.id))
-    if (partToUpdateIndex) {
+    const partToUpdateIndex: number | undefined = rundown.segments[segmentForPartIndex].parts.findIndex(existingPart => part.segmentId.startsWith(existingPart.segmentId))
+    if (partToUpdateIndex > -1) {
       rundown.segments[segmentForPartIndex].parts[partToUpdateIndex] = part
     }
     return rundown

--- a/src/app/core/services/rundown-state.service.ts
+++ b/src/app/core/services/rundown-state.service.ts
@@ -52,8 +52,8 @@ export class RundownStateService implements OnDestroy {
   }
 
   private subscribeToEvents(): void {
-    const connectionStatusSubscriptions = this.subscribeToConnectionStatus()
-    const rundownEventSubscriptions = this.subscribeToRundownEvents()
+    const connectionStatusSubscriptions: EventSubscription[] = this.subscribeToConnectionStatus()
+    const rundownEventSubscriptions: EventSubscription[] = this.subscribeToRundownEvents()
     this.eventSubscriptions = [...rundownEventSubscriptions, ...connectionStatusSubscriptions]
   }
 

--- a/src/app/rundown-view/components/rundown/rundown.component.ts
+++ b/src/app/rundown-view/components/rundown/rundown.component.ts
@@ -12,8 +12,7 @@ import { EventSubscription } from 'src/app/event-system/abstractions/event-obser
 import { ActionStateService } from '../../../shared/services/action-state.service'
 import { Action } from '../../../shared/models/action'
 import { Tv2Action, Tv2ActionContentType, Tv2VideoClipAction } from '../../../shared/models/tv2-action'
-import { PartEvent, RundownInfinitePiecesUpdatedEvent } from '../../../core/models/rundown-event'
-import { Piece } from '../../../core/models/piece'
+import { PartEvent } from '../../../core/models/rundown-event'
 
 const SMOOTH_SCROLL_CONFIGURATION: ScrollIntoViewOptions = {
   behavior: 'smooth',
@@ -69,17 +68,7 @@ export class RundownComponent implements OnInit, OnDestroy, OnChanges {
     this.subscribeToEventObserver()
   }
 
-  private updateInfinitePieces(event: RundownInfinitePiecesUpdatedEvent): void {
-    event.infinitePieces.forEach((infinitePiece: Piece) => {
-      this.rundown.segments
-        .find(segment => segment.isOnAir)
-        ?.parts.find(part => part.id === infinitePiece.partId)
-        ?.pieces.push(infinitePiece)
-    })
-  }
-
   private subscribeToEventObserver(): void {
-    this.rundownEventSubscriptions.push(this.rundownEventObserver.subscribeToRundownInfinitePiecesUpdated(this.updateInfinitePieces.bind(this)))
     this.rundownEventSubscriptions.push(this.rundownEventObserver.subscribeToRundownAutoNext(this.setAutoNextStartedToTrue.bind(this)))
     this.rundownEventSubscriptions.push(this.rundownEventObserver.subscribeToRundownReset(this.setAutoNextStartedToFalse.bind(this)))
     this.rundownEventSubscriptions.push(this.rundownEventObserver.subscribeToRundownDeactivation(this.setAutoNextStartedToFalse.bind(this)))


### PR DESCRIPTION
This PR fixes GUI that doesn’t update when RundownInfinitePiecesUpdated event deliver piece.
note: replaces https://github.com/tv2/ng-sofie/pull/110