### PR TITLE
Sof 1560/update snackbar notification popup

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,4 +1,3 @@
 :host {
   height: 100%;
-  overflow: hidden;
 }

--- a/src/app/core/services/action-trigger-state.service.spec.ts
+++ b/src/app/core/services/action-trigger-state.service.spec.ts
@@ -4,7 +4,7 @@ import { ConnectionStatusObserver } from './connection-status-observer.service'
 import { ActionTriggerEventObserver } from './action-trigger-event-observer.service'
 import { instance, mock, when } from '@typestrong/ts-mockito'
 import { of } from 'rxjs'
-import { MatSnackBar } from '@angular/material/snack-bar'
+import { NotificationService } from '../../shared/services/notification.service'
 
 describe(ActionTriggerStateService.name, () => {
   it('should be created', () => {
@@ -13,11 +13,10 @@ describe(ActionTriggerStateService.name, () => {
 
     const connectionStatusObserver: ConnectionStatusObserver = mock(ConnectionStatusObserver)
     const actionTriggerEventObserver: ActionTriggerEventObserver = mock(ActionTriggerEventObserver)
-    const mockedMatSnackBar = mock<MatSnackBar>()
     const testee: ActionTriggerStateService = new ActionTriggerStateService(
       instance(actionTriggerService),
       instance(connectionStatusObserver),
-      instance(mockedMatSnackBar),
+      instance(mock(NotificationService)),
       instance(actionTriggerEventObserver)
     )
 

--- a/src/app/core/services/action-trigger-state.service.ts
+++ b/src/app/core/services/action-trigger-state.service.ts
@@ -6,7 +6,7 @@ import { ActionTriggerService } from '../../shared/abstractions/action-trigger.s
 import { EventSubscription } from '../../event-system/abstractions/event-observer.service'
 import { ActionTriggerCreatedEvent, ActionTriggerDeletedEvent, ActionTriggerUpdatedEvent } from '../models/action-trigger-event'
 import { ActionTriggerEventObserver } from './action-trigger-event-observer.service'
-import { MatSnackBar } from '@angular/material/snack-bar'
+import { NotificationService } from '../../shared/services/notification.service'
 
 @Injectable()
 export class ActionTriggerStateService {
@@ -17,7 +17,7 @@ export class ActionTriggerStateService {
   constructor(
     private readonly actionTriggerService: ActionTriggerService,
     private readonly connectionStatusObserver: ConnectionStatusObserver,
-    private readonly snackBar: MatSnackBar,
+    private readonly notificationService: NotificationService,
     private readonly actionTriggerEventObserver: ActionTriggerEventObserver
   ) {
     this.subscriptions.push(this.connectionStatusObserver.subscribeToReconnect(() => this.resetActionTriggers()))
@@ -45,12 +45,12 @@ export class ActionTriggerStateService {
     const actionTriggers: ActionTrigger[] = this.actionTriggersSubject.value
     const index: number = actionTriggers.findIndex(actionTrigger => actionTrigger.id === actionTriggerUpdatedEvent.actionTrigger.id)
     if (index === -1) {
-      this.openDangerSnackBar('Failed to updated shortcut')
+      this.notificationService.createErrorNotification('Failed to updated shortcut')
       return
     }
     actionTriggers[index] = actionTriggerUpdatedEvent.actionTrigger
     this.actionTriggersSubject.next(actionTriggers)
-    this.openSnackBar('Successfully updated shortcut')
+    this.notificationService.createInfoNotification('Successfully updated shortcut')
   }
 
   private removeActionTriggerFromEvent(actionTriggerDeletedEvent: ActionTriggerDeletedEvent): void {
@@ -62,13 +62,13 @@ export class ActionTriggerStateService {
     }
     actionTriggers.splice(index, 1)
     this.actionTriggersSubject.next(actionTriggers)
-    this.openSnackBar('Successfully deleted shortcut')
+    this.notificationService.createInfoNotification('Successfully deleted shortcut')
   }
 
   private createActionTriggerFromEvent(actionTriggerCreatedEvent: ActionTriggerCreatedEvent): void {
     const updatedActionTriggers: ActionTrigger[] = [...this.actionTriggersSubject.value, actionTriggerCreatedEvent.actionTrigger]
     this.actionTriggersSubject.next(updatedActionTriggers)
-    this.openSnackBar('Successfully created shortcut.')
+    this.notificationService.createInfoNotification('Successfully created shortcut.')
   }
 
   public getActionTriggerObservable(): Observable<ActionTrigger[]> {
@@ -77,13 +77,5 @@ export class ActionTriggerStateService {
 
   public destroy(): void {
     this.subscriptions.forEach(subscription => subscription.unsubscribe)
-  }
-
-  private openSnackBar(message: string): void {
-    this.snackBar.open(message, $localize`global.dismiss.label`, { panelClass: 'snackbar-success' })
-  }
-
-  private openDangerSnackBar(message: string): void {
-    this.snackBar.open(message, $localize`global.dismiss.label`, { panelClass: 'snackbar-danger' })
   }
 }

--- a/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.html
+++ b/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.html
@@ -1,4 +1,5 @@
-<sofie-header></sofie-header>
+<sofie-header #header></sofie-header>
+<sofie-notification-container [topOffset]="header.elementRef.nativeElement.offsetHeight"></sofie-notification-container>
 
 <h1 class="c-rundown-overview__title" i18n>rundown-overview.rundown-overview.title</h1>
 

--- a/src/app/rundown-view/components/rundown-header/rundown-header.component.ts
+++ b/src/app/rundown-view/components/rundown-header/rundown-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChange, SimpleChanges } from '@angular/core'
+import { Component, ElementRef, Input, OnChanges, OnDestroy, OnInit, SimpleChange, SimpleChanges } from '@angular/core'
 import { Rundown } from '../../../core/models/rundown'
 import { Piece } from '../../../core/models/piece'
 import { ShowStyleVariantStateService } from '../../../core/services/show-style-variant-state.service'
@@ -38,12 +38,16 @@ export class RundownHeaderComponent implements OnInit, OnDestroy, OnChanges {
   private rundownTimingContextSubscription?: Subscription
   private readonly logger: Logger
 
+  public elementRef: ElementRef
+
   constructor(
+    private readonly elementReference: ElementRef,
     private readonly showStyleVariantStateService: ShowStyleVariantStateService,
     private readonly rundownTimingContextStateService: RundownTimingContextStateService,
     logger: Logger
   ) {
     this.logger = logger.tag('RundownHeaderComponent')
+    this.elementRef = elementReference
   }
 
   public ngOnInit(): void {

--- a/src/app/rundown-view/components/rundown-header/rundown-header.component.ts
+++ b/src/app/rundown-view/components/rundown-header/rundown-header.component.ts
@@ -41,7 +41,7 @@ export class RundownHeaderComponent implements OnInit, OnDestroy, OnChanges {
   public elementRef: ElementRef
 
   constructor(
-    private readonly elementReference: ElementRef,
+    elementReference: ElementRef,
     private readonly showStyleVariantStateService: ShowStyleVariantStateService,
     private readonly rundownTimingContextStateService: RundownTimingContextStateService,
     logger: Logger

--- a/src/app/rundown-view/components/rundown-view/rundown-view.component.html
+++ b/src/app/rundown-view/components/rundown-view/rundown-view.component.html
@@ -6,7 +6,7 @@
 
 <ng-template #rundownLoaded>
     <ng-container *ngIf="rundown; else rundownRemoved">
-        <sofie-rundown-header [rundown]="rundown"></sofie-rundown-header>
+        <sofie-rundown-header #headerComponent [rundown]="rundown"></sofie-rundown-header>
         <sofie-on-air-details-panel *ngIf="rundown.isActive" [rundown]="rundown"></sofie-on-air-details-panel>
         <sofie-rundown [rundown]="rundown"></sofie-rundown>
         <sofie-draggable-shelf localStorageKey="producer-shelf">
@@ -16,6 +16,7 @@
                     [rundown]="rundown"
             ></sofie-producer-shelf>
         </sofie-draggable-shelf>
+        <sofie-notification-container [topOffset]="headerComponent.elementRef.nativeElement.offsetHeight"></sofie-notification-container>
     </ng-container>
 </ng-template>
 

--- a/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.spec.ts
+++ b/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.spec.ts
@@ -2,8 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { ActionTriggersImportComponent } from './action-triggers-import.component'
 import { mock } from '@typestrong/ts-mockito'
 import { ActionTriggerParser } from 'src/app/shared/abstractions/action-trigger-parser.service'
-import { MatSnackBar } from '@angular/material/snack-bar'
 import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
+import { NotificationService } from '../../../../shared/services/notification.service'
 
 describe('ActionTriggersImportComponent', () => {
   it('should create', async () => {
@@ -15,12 +15,11 @@ describe('ActionTriggersImportComponent', () => {
 async function configureTestBed(): Promise<ActionTriggersImportComponent> {
   const mockedActionTriggerService: ActionTriggerService = mock<ActionTriggerService>()
   const mockedActionTriggerParser: ActionTriggerParser = mock<ActionTriggerParser>()
-  const mockedMatSnackBar = mock<MatSnackBar>()
   await TestBed.configureTestingModule({
     providers: [
       { provide: ActionTriggerService, useValue: mockedActionTriggerService },
       { provide: ActionTriggerParser, useValue: mockedActionTriggerParser },
-      { provide: MatSnackBar, useValue: mockedMatSnackBar },
+      { provide: NotificationService, useValue: mock(NotificationService) },
     ],
     declarations: [ActionTriggersImportComponent],
   }).compileComponents()

--- a/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.ts
+++ b/src/app/settings/action-triggers/components/action-triggers-import/action-triggers-import.component.ts
@@ -1,10 +1,10 @@
 import { lastValueFrom } from 'rxjs'
 import { Component, Input } from '@angular/core'
 import { ActionTrigger, ActionTriggerWithAction } from 'src/app/shared/models/action-trigger'
-import { MatSnackBar } from '@angular/material/snack-bar'
 import { ActionTriggerParser } from 'src/app/shared/abstractions/action-trigger-parser.service'
 import { ActionTriggerService } from 'src/app/shared/abstractions/action-trigger.service'
 import { KeyboardTriggerData } from 'src/app/shared/models/keyboard-trigger'
+import { NotificationService } from '../../../../shared/services/notification.service'
 
 @Component({
   selector: 'sofie-action-triggers-import',
@@ -18,13 +18,13 @@ export class ActionTriggersImportComponent {
   constructor(
     private readonly actionTriggerService: ActionTriggerService,
     private readonly actionTriggerParser: ActionTriggerParser,
-    private readonly snackBar: MatSnackBar
+    private readonly notificationService: NotificationService
   ) {}
 
   public uploadFile(inputElement: HTMLInputElement): void {
     const files = inputElement.files
     if (!files?.[0]) {
-      this.openDangerSnackBar('Error in imported file')
+      this.notificationService.createErrorNotification('Error in imported file')
       return
     }
     const reader = new FileReader()
@@ -34,14 +34,14 @@ export class ActionTriggersImportComponent {
           JSON.parse(readerProcessEvent?.target?.result ? readerProcessEvent.target.result.toString() : '')
         )
         if (importedActionTriggers.length === 0) {
-          this.openDangerSnackBar('No items to be added')
+          this.notificationService.createErrorNotification('No items to be added')
           return
         }
         this.importActionTriggers(importedActionTriggers).catch(() => {
-          this.openDangerSnackBar('Error in imported file')
+          this.notificationService.createErrorNotification('Error in imported file')
         })
       } catch {
-        this.openDangerSnackBar('Error in imported file')
+        this.notificationService.createErrorNotification('Error in imported file')
       }
       inputElement.value = ''
     }
@@ -58,9 +58,5 @@ export class ActionTriggersImportComponent {
         ? this.actionTriggerService.updateActionTrigger(actionTriggerToImport)
         : this.actionTriggerService.createActionTrigger(actionTriggerToImport)
     )
-  }
-
-  private openDangerSnackBar(message: string): void {
-    this.snackBar.open(message, $localize`global.dismiss.label`, { panelClass: 'snackbar-danger' })
   }
 }

--- a/src/app/settings/components/clear-cache/clear-cache.component.spec.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.spec.ts
@@ -4,7 +4,7 @@ import { instance, mock } from '@typestrong/ts-mockito'
 import { HttpClient } from '@angular/common/http'
 import { DialogService } from 'src/app/shared/services/dialog.service'
 import { ConfigurationService } from '../../../shared/services/configuration.service'
-import { MatSnackBar } from '@angular/material/snack-bar'
+import { NotificationService } from '../../../shared/services/notification.service'
 
 describe('ClearCacheComponent', () => {
   it('should create', async () => {
@@ -20,7 +20,7 @@ async function configureTestBed(): Promise<ClearCacheComponent> {
       { provide: DialogService, useValue: instance(mock<DialogService>) },
       { provide: HttpClient, useValue: instance(mock<HttpClient>()) },
       { provide: ConfigurationService, useValue: instance(mock<ConfigurationService>()) },
-      { provide: MatSnackBar, useValue: instance(mock(MatSnackBar)) },
+      { provide: NotificationService, useValue: instance(mock(NotificationService)) },
     ],
   }).compileComponents()
   const fixture: ComponentFixture<ClearCacheComponent> = TestBed.createComponent(ClearCacheComponent)

--- a/src/app/settings/components/clear-cache/clear-cache.component.ts
+++ b/src/app/settings/components/clear-cache/clear-cache.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core'
 import { DialogService } from 'src/app/shared/services/dialog.service'
 import { ConfigurationService } from '../../../shared/services/configuration.service'
-import { MatSnackBar } from '@angular/material/snack-bar'
+import { NotificationService } from '../../../shared/services/notification.service'
 
 @Component({
   selector: 'sofie-clear-cache',
@@ -12,7 +12,7 @@ export class ClearCacheComponent {
   constructor(
     private readonly configurationService: ConfigurationService,
     private readonly dialogService: DialogService,
-    private readonly snackbar: MatSnackBar
+    private readonly notificationService: NotificationService
   ) {}
 
   public showClearCacheConfirmModal(): void {
@@ -22,9 +22,7 @@ export class ClearCacheComponent {
   public clearConfigurationCache(): void {
     this.configurationService.clearConfigurationCache().subscribe(() => {
       // Note: This functionality is only until we control the entire settings page, so there should be no need for translation.
-      this.snackbar.open('The configuration cache was cleared', $localize`global.dismiss.label`, {
-        panelClass: 'snackbar-success',
-      })
+      this.notificationService.createInfoNotification('The configuration cache was cleared')
     })
   }
 }

--- a/src/app/settings/components/settings/settings.component.html
+++ b/src/app/settings/components/settings/settings.component.html
@@ -1,4 +1,5 @@
-<sofie-header></sofie-header>
+<sofie-header #header></sofie-header>
+<sofie-notification-container [topOffset]="header.elementRef.nativeElement.offsetHeight"></sofie-notification-container>
 
 <div class="c-settings">
   <div class="c-settings__menu"><sofie-settings-menu></sofie-settings-menu></div>

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core'
+import { Component, ElementRef, OnInit } from '@angular/core'
 import { Paths } from '../../../app-routing.module'
 import { Router } from '@angular/router'
 import { Logger } from '../../../core/abstractions/logger.service'
@@ -11,14 +11,18 @@ import { Title } from '@angular/platform-browser'
 })
 export class HeaderComponent implements OnInit {
   public title: string
+  public elementRef: ElementRef
+
   private readonly logger: Logger
 
   constructor(
+    private readonly elementReference: ElementRef,
     private readonly router: Router,
     private readonly titleService: Title,
     logger: Logger
   ) {
     this.logger = logger.tag('HeaderComponent')
+    this.elementRef = elementReference
   }
 
   public ngOnInit(): void {

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -16,7 +16,7 @@ export class HeaderComponent implements OnInit {
   private readonly logger: Logger
 
   constructor(
-    private readonly elementReference: ElementRef,
+    elementReference: ElementRef,
     private readonly router: Router,
     private readonly titleService: Title,
     logger: Logger

--- a/src/app/shared/components/notification-container/notification-container.component.scss
+++ b/src/app/shared/components/notification-container/notification-container.component.scss
@@ -1,0 +1,8 @@
+$container-width: 300px;
+
+:host {
+  position: absolute;
+  width: $container-width;
+  //top: 0;
+  right: 0;
+}

--- a/src/app/shared/components/notification-container/notification-container.component.scss
+++ b/src/app/shared/components/notification-container/notification-container.component.scss
@@ -3,6 +3,4 @@ $container-width: 300px;
 :host {
   position: absolute;
   width: $container-width;
-  //top: 0;
-  right: 0;
 }

--- a/src/app/shared/components/notification-container/notification-container.component.spec.ts
+++ b/src/app/shared/components/notification-container/notification-container.component.spec.ts
@@ -1,0 +1,11 @@
+import { NotificationContainerComponent } from './notification-container.component'
+import { instance, mock } from '@typestrong/ts-mockito'
+import { ApplicationRef, ElementRef } from '@angular/core'
+import { NotificationService } from '../../services/notification.service'
+
+describe('NotificationContainerComponent', () => {
+  it('should create', () => {
+    const testee: NotificationContainerComponent = new NotificationContainerComponent(instance(mock(ElementRef)), instance(mock(ApplicationRef)), instance(mock(NotificationService)))
+    expect(testee).toBeTruthy()
+  })
+})

--- a/src/app/shared/components/notification-container/notification-container.component.ts
+++ b/src/app/shared/components/notification-container/notification-container.component.ts
@@ -1,0 +1,101 @@
+import { AfterViewInit, ApplicationRef, Component, ComponentRef, createComponent, ElementRef, EmbeddedViewRef, Input, OnDestroy, OnInit } from '@angular/core'
+import { NotificationService } from '../../services/notification.service'
+import { Subject, takeUntil } from 'rxjs'
+import { NotificationComponent } from '../notification/notification.component'
+
+const NOTIFICATION_DURATION_MS: number = 5000
+const TOP_PADDING: number = 5
+const PIXEL_POSTFIX: string = 'px'
+
+const STACK_GAP: number = 15
+
+@Component({
+  selector: 'sofie-notification-container',
+  templateUrl: './notification-container.component.html',
+  styleUrls: ['./notification-container.component.scss'],
+})
+export class NotificationContainerComponent implements OnInit, OnDestroy, AfterViewInit {
+  @Input()
+  public topOffset: number
+
+  private readonly destroySubject: Subject<void> = new Subject()
+
+  private readonly notificationElements: HTMLElement[] = []
+
+  constructor(
+    private readonly elementRef: ElementRef,
+    private readonly applicationRef: ApplicationRef,
+    private readonly notificationService: NotificationService
+  ) {}
+
+  public ngAfterViewInit(): void {
+    this.elementRef.nativeElement.style.top = TOP_PADDING + this.topOffset + PIXEL_POSTFIX
+  }
+
+  public ngOnInit(): void {
+    this.notificationService
+      .subscribeToNotifications()
+      .pipe(takeUntil(this.destroySubject))
+      .subscribe(() => this.createNotification())
+  }
+
+  private createNotification(): void {
+    const notificationElement: HTMLElement = this.createNotificationElement()
+    this.insertNotificationIntoContainer(notificationElement)
+    this.setRemoveNotificationTimer(notificationElement)
+    this.moveNotificationsDown()
+  }
+
+  private createNotificationElement(): HTMLElement {
+    const notificationComponentRef: ComponentRef<NotificationComponent> = createComponent(NotificationComponent, {
+      environmentInjector: this.applicationRef.injector,
+    })
+
+    notificationComponentRef.instance.onRemoveCallback = (notificationElement: HTMLElement): void => this.removeNotificationElement(notificationElement)
+    notificationComponentRef.changeDetectorRef.detectChanges()
+
+    return (<EmbeddedViewRef<NotificationComponent>>notificationComponentRef.hostView).rootNodes[0]
+  }
+
+  private insertNotificationIntoContainer(notificationElement: HTMLElement): void {
+    const host: HTMLElement = this.elementRef.nativeElement
+    host.insertAdjacentElement('afterbegin', notificationElement)
+    this.notificationElements.unshift(notificationElement)
+  }
+
+  private setRemoveNotificationTimer(notificationElement: HTMLElement): void {
+    setTimeout(() => this.removeNotificationElement(notificationElement), NOTIFICATION_DURATION_MS)
+  }
+
+  private removeNotificationElement(notificationElement: HTMLElement): void {
+    notificationElement.remove()
+    const index: number = this.notificationElements.indexOf(notificationElement)
+    if (index === -1) {
+      return
+    }
+    this.notificationElements.splice(index, 1)
+
+    for (let i = index; i < this.notificationElements.length; i++) {
+      const element: HTMLElement = this.notificationElements[i]
+      element.style.top = (element.offsetHeight + STACK_GAP) * i + PIXEL_POSTFIX
+    }
+  }
+
+  private moveNotificationsDown(): void {
+    if (this.notificationElements.length < 2) {
+      return
+    }
+    const offsetGap: number = 0
+    let spaceFromTop: number = this.notificationElements[0].offsetHeight + offsetGap + STACK_GAP
+    for (let i = 1; i < this.notificationElements.length; i++) {
+      const notificationElement: HTMLElement = this.notificationElements[i]
+      notificationElement.style.top = spaceFromTop + PIXEL_POSTFIX
+      spaceFromTop += notificationElement.offsetHeight + STACK_GAP
+    }
+  }
+
+  public ngOnDestroy(): void {
+    this.destroySubject.next()
+    this.destroySubject.complete()
+  }
+}

--- a/src/app/shared/components/notification-container/notification-container.component.ts
+++ b/src/app/shared/components/notification-container/notification-container.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, ApplicationRef, Component, ComponentRef, createComponent
 import { NotificationService } from '../../services/notification.service'
 import { Subject, takeUntil } from 'rxjs'
 import { NotificationComponent } from '../notification/notification.component'
+import { Notification } from '../../models/notification'
 
 const NOTIFICATION_DURATION_MS: number = 5000
 const TOP_PADDING: number = 5
@@ -40,21 +41,22 @@ export class NotificationContainerComponent implements OnInit, OnDestroy, AfterV
     this.notificationService
       .subscribeToNotifications()
       .pipe(takeUntil(this.destroySubject))
-      .subscribe(() => this.createNotification())
+      .subscribe((notification: Notification) => this.createNotification(notification))
   }
 
-  private createNotification(): void {
-    const notificationElement: HTMLElement = this.createNotificationElement()
+  private createNotification(notification: Notification): void {
+    const notificationElement: HTMLElement = this.createNotificationElement(notification)
     this.insertNotificationIntoContainer(notificationElement)
     this.setRemoveNotificationTimer(notificationElement)
     this.moveNotificationsDown()
   }
 
-  private createNotificationElement(): HTMLElement {
+  private createNotificationElement(notification: Notification): HTMLElement {
     const notificationComponentRef: ComponentRef<NotificationComponent> = createComponent(NotificationComponent, {
       environmentInjector: this.applicationRef.injector,
     })
 
+    notificationComponentRef.instance.notification = notification
     notificationComponentRef.instance.onRemoveCallback = (notificationElement: HTMLElement): void => this.removeNotificationElement(notificationElement)
     notificationComponentRef.changeDetectorRef.detectChanges()
 

--- a/src/app/shared/components/notification-container/notification-container.component.ts
+++ b/src/app/shared/components/notification-container/notification-container.component.ts
@@ -7,7 +7,7 @@ const NOTIFICATION_DURATION_MS: number = 5000
 const TOP_PADDING: number = 5
 const PIXEL_POSTFIX: string = 'px'
 
-const STACK_GAP: number = 15
+const STACK_GAP: number = 5
 
 @Component({
   selector: 'sofie-notification-container',
@@ -16,7 +16,10 @@ const STACK_GAP: number = 15
 })
 export class NotificationContainerComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input()
-  public topOffset: number
+  public topOffset: number = 0
+
+  @Input()
+  public rightOffset: number = 0
 
   private readonly destroySubject: Subject<void> = new Subject()
 
@@ -30,6 +33,7 @@ export class NotificationContainerComponent implements OnInit, OnDestroy, AfterV
 
   public ngAfterViewInit(): void {
     this.elementRef.nativeElement.style.top = TOP_PADDING + this.topOffset + PIXEL_POSTFIX
+    this.elementRef.nativeElement.style.right = this.rightOffset + PIXEL_POSTFIX
   }
 
   public ngOnInit(): void {

--- a/src/app/shared/components/notification-container/notification-container.component.ts
+++ b/src/app/shared/components/notification-container/notification-container.component.ts
@@ -4,7 +4,7 @@ import { Subject, takeUntil } from 'rxjs'
 import { NotificationComponent } from '../notification/notification.component'
 import { Notification } from '../../models/notification'
 
-const NOTIFICATION_DURATION_MS: number = 5000
+const NOTIFICATION_DURATION_MS: number = 7000
 const TOP_PADDING: number = 5
 const PIXEL_POSTFIX: string = 'px'
 
@@ -48,7 +48,7 @@ export class NotificationContainerComponent implements OnInit, OnDestroy, AfterV
     const notificationElement: HTMLElement = this.createNotificationElement(notification)
     this.insertNotificationIntoContainer(notificationElement)
     this.setRemoveNotificationTimer(notificationElement)
-    this.moveNotificationsDown()
+    this.moveNotifications()
   }
 
   private createNotificationElement(notification: Notification): HTMLElement {
@@ -81,22 +81,19 @@ export class NotificationContainerComponent implements OnInit, OnDestroy, AfterV
     }
     this.notificationElements.splice(index, 1)
 
-    for (let i = index; i < this.notificationElements.length; i++) {
-      const element: HTMLElement = this.notificationElements[i]
-      element.style.top = (element.offsetHeight + STACK_GAP) * i + PIXEL_POSTFIX
-    }
+    this.moveNotifications()
   }
 
-  private moveNotificationsDown(): void {
-    if (this.notificationElements.length < 2) {
+  private moveNotifications(): void {
+    if (this.notificationElements.length === 0) {
       return
     }
-    const offsetGap: number = 0
-    let spaceFromTop: number = this.notificationElements[0].offsetHeight + offsetGap + STACK_GAP
+    this.notificationElements[0].style.top = 0 + PIXEL_POSTFIX
+    let top: number = this.notificationElements[0].offsetHeight + STACK_GAP
     for (let i = 1; i < this.notificationElements.length; i++) {
       const notificationElement: HTMLElement = this.notificationElements[i]
-      notificationElement.style.top = spaceFromTop + PIXEL_POSTFIX
-      spaceFromTop += notificationElement.offsetHeight + STACK_GAP
+      notificationElement.style.top = top + PIXEL_POSTFIX
+      top += notificationElement.offsetHeight + STACK_GAP
     }
   }
 

--- a/src/app/shared/components/notification/notification.component.html
+++ b/src/app/shared/components/notification/notification.component.html
@@ -1,4 +1,4 @@
-<div>
-    Hello world!
-    <button (click)="remove()">Remove me</button>
+<div class="notification-body">
+    <span class="text">Hello world! Hello world! Hello world! Hello world! Hello world! Hello world! Hello world!</span>
+    <sofie-icon-button (click)="remove()" [iconButton]="IconButton.XMARK" [iconButtonSize]="IconButtonSize.M"></sofie-icon-button>
 </div>

--- a/src/app/shared/components/notification/notification.component.html
+++ b/src/app/shared/components/notification/notification.component.html
@@ -1,0 +1,4 @@
+<div>
+    Hello world!
+    <button (click)="remove()">Remove me</button>
+</div>

--- a/src/app/shared/components/notification/notification.component.html
+++ b/src/app/shared/components/notification/notification.component.html
@@ -1,4 +1,4 @@
 <div class="notification-body">
-    <span class="text">Hello world! Hello world! Hello world! Hello world! Hello world! Hello world! Hello world!</span>
+    <div class="text">{{notification.message}}</div>
     <sofie-icon-button (click)="remove()" [iconButton]="IconButton.XMARK" [iconButtonSize]="IconButtonSize.M"></sofie-icon-button>
 </div>

--- a/src/app/shared/components/notification/notification.component.scss
+++ b/src/app/shared/components/notification/notification.component.scss
@@ -8,7 +8,7 @@ $animation-fill-mode: forwards;
   padding: 10px;
   border-radius: 10px;
   box-sizing: border-box;
-  box-shadow: 1px 1px 2px var(--black-color);
+  box-shadow: 1px 1px 2px var(--black-color-with-alpha);
   position: absolute;
   display: flex;
   top: 0;

--- a/src/app/shared/components/notification/notification.component.scss
+++ b/src/app/shared/components/notification/notification.component.scss
@@ -8,6 +8,7 @@ $animation-fill-mode: forwards;
   padding: 10px;
   border-radius: 10px;
   box-sizing: border-box;
+  box-shadow: 1px 1px 2px var(--black-color);
   position: absolute;
   display: flex;
   top: 0;

--- a/src/app/shared/components/notification/notification.component.scss
+++ b/src/app/shared/components/notification/notification.component.scss
@@ -31,6 +31,8 @@ $animation-fill-mode: forwards;
 
 .text {
   padding-left: var(--status-color-width);
+  overflow-wrap: break-word;
+  width: 95%;
 }
 
 sofie-icon-button {

--- a/src/app/shared/components/notification/notification.component.scss
+++ b/src/app/shared/components/notification/notification.component.scss
@@ -1,0 +1,23 @@
+$animation-duration: 0.3s;
+$animation-function: ease;
+$animation-fill-mode: forwards;
+
+:host {
+  color: white;
+  background: #222;
+  padding: 10px;
+  border-radius: 3px;
+  box-sizing: border-box;
+  position: absolute;
+  display: inline-flex;
+  top: 0;
+  left: 0;
+  transform: translateX(500px);
+  transition: top $animation-duration $animation-function;
+  animation: slide-from-right $animation-duration $animation-function $animation-fill-mode;
+  z-index: 50;
+}
+
+@keyframes slide-from-right {
+  100% { transform: translateX(0) }
+}

--- a/src/app/shared/components/notification/notification.component.scss
+++ b/src/app/shared/components/notification/notification.component.scss
@@ -3,15 +3,16 @@ $animation-function: ease;
 $animation-fill-mode: forwards;
 
 :host {
-  color: white;
-  background: #222;
+  --gradient-degree: 90deg;
+  --status-color-width: 5%;
   padding: 10px;
-  border-radius: 3px;
+  border-radius: 10px;
   box-sizing: border-box;
   position: absolute;
-  display: inline-flex;
+  display: flex;
   top: 0;
   left: 0;
+  width: 98%;
   transform: translateX(500px);
   transition: top $animation-duration $animation-function;
   animation: slide-from-right $animation-duration $animation-function $animation-fill-mode;
@@ -20,4 +21,18 @@ $animation-fill-mode: forwards;
 
 @keyframes slide-from-right {
   100% { transform: translateX(0) }
+}
+
+.notification-body {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.text {
+  padding-left: var(--status-color-width);
+}
+
+sofie-icon-button {
+  padding-right: 2px;
 }

--- a/src/app/shared/components/notification/notification.component.spec.ts
+++ b/src/app/shared/components/notification/notification.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { NotificationComponent } from './notification.component'
+
+describe('NotificationComponent', () => {
+  let component: NotificationComponent
+  let fixture: ComponentFixture<NotificationComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NotificationComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(NotificationComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/shared/components/notification/notification.component.spec.ts
+++ b/src/app/shared/components/notification/notification.component.spec.ts
@@ -1,22 +1,10 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing'
-
 import { NotificationComponent } from './notification.component'
+import { instance, mock } from '@typestrong/ts-mockito'
+import { ElementRef } from '@angular/core'
 
 describe('NotificationComponent', () => {
-  let component: NotificationComponent
-  let fixture: ComponentFixture<NotificationComponent>
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NotificationComponent],
-    }).compileComponents()
-
-    fixture = TestBed.createComponent(NotificationComponent)
-    component = fixture.componentInstance
-    fixture.detectChanges()
-  })
-
   it('should create', () => {
-    expect(component).toBeTruthy()
+    const testee: NotificationComponent = new NotificationComponent(instance(mock(ElementRef)))
+    expect(testee).toBeTruthy()
   })
 })

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -1,0 +1,17 @@
+import { Component, ElementRef, Input } from '@angular/core'
+
+@Component({
+  selector: 'sofie-notification',
+  templateUrl: './notification.component.html',
+  styleUrls: ['./notification.component.scss'],
+})
+export class NotificationComponent {
+  @Input()
+  public onRemoveCallback: (element: HTMLElement) => void
+
+  constructor(private readonly elementRef: ElementRef) {}
+
+  public remove(): void {
+    this.onRemoveCallback(this.elementRef.nativeElement)
+  }
+}

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -1,4 +1,13 @@
 import { Component, ElementRef, Input } from '@angular/core'
+import { IconButton, IconButtonSize } from '../../enums/icon-button'
+
+const INFO_COLOR: string = 'var(--blue-color)'
+const WARNING_COLOR: string = 'var(--yellow-color)'
+const ERROR_COLOR: string = 'var(--danger-color)'
+
+const GRADIENT_DEGREE: string = 'var(--gradient-degree)'
+const STATUS_COLOR_WIDTH: string = 'var(--status-color-width)'
+const BACKGROUND_COLOR: string = 'var(--white-color)'
 
 @Component({
   selector: 'sofie-notification',
@@ -9,9 +18,24 @@ export class NotificationComponent {
   @Input()
   public onRemoveCallback: (element: HTMLElement) => void
 
-  constructor(private readonly elementRef: ElementRef) {}
+  public readonly IconButton = IconButton
+  public readonly IconButtonSize = IconButtonSize
+
+  constructor(private readonly elementRef: ElementRef) {
+    this.setBackground()
+  }
 
   public remove(): void {
     this.onRemoveCallback(this.elementRef.nativeElement)
+  }
+
+  private setBackground(): void {
+    const statusColor: string = this.getStatusColor()
+    this.elementRef.nativeElement.style.background = `linear-gradient(${GRADIENT_DEGREE}, ${statusColor}, ${statusColor} ${STATUS_COLOR_WIDTH}, ${BACKGROUND_COLOR} ${STATUS_COLOR_WIDTH}, ${BACKGROUND_COLOR})`
+  }
+
+  private getStatusColor(): string {
+    const isEven: number = Math.floor(Math.random() * 10) % 2
+    return isEven ? INFO_COLOR : ERROR_COLOR
   }
 }

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -1,5 +1,7 @@
-import { Component, ElementRef, Input } from '@angular/core'
+import { Component, ElementRef, Input, OnInit } from '@angular/core'
 import { IconButton, IconButtonSize } from '../../enums/icon-button'
+import { Notification } from '../../models/notification'
+import { StatusCode } from '../../enums/status-code'
 
 const INFO_COLOR: string = 'var(--blue-color)'
 const WARNING_COLOR: string = 'var(--yellow-color)'
@@ -14,14 +16,18 @@ const BACKGROUND_COLOR: string = 'var(--white-color)'
   templateUrl: './notification.component.html',
   styleUrls: ['./notification.component.scss'],
 })
-export class NotificationComponent {
+export class NotificationComponent implements OnInit {
+  @Input()
+  public notification: Notification
   @Input()
   public onRemoveCallback: (element: HTMLElement) => void
 
   public readonly IconButton = IconButton
   public readonly IconButtonSize = IconButtonSize
 
-  constructor(private readonly elementRef: ElementRef) {
+  constructor(private readonly elementRef: ElementRef) {}
+
+  public ngOnInit(): void {
     this.setBackground()
   }
 
@@ -35,7 +41,16 @@ export class NotificationComponent {
   }
 
   private getStatusColor(): string {
-    const isEven: number = Math.floor(Math.random() * 10) % 2
-    return isEven ? INFO_COLOR : ERROR_COLOR
+    switch (this.notification.statusCode) {
+      case StatusCode.WARNING: {
+        return WARNING_COLOR
+      }
+      case StatusCode.BAD: {
+        return ERROR_COLOR
+      }
+      default: {
+        return INFO_COLOR
+      }
+    }
   }
 }

--- a/src/app/shared/enums/status-code.ts
+++ b/src/app/shared/enums/status-code.ts
@@ -1,0 +1,6 @@
+export enum StatusCode {
+  GOOD = 'GOOD',
+  WARNING = 'WARNING',
+  BAD = 'BAD',
+  UNKNOWN = 'UNKNOWN',
+}

--- a/src/app/shared/models/notification.ts
+++ b/src/app/shared/models/notification.ts
@@ -1,0 +1,6 @@
+import { StatusCode } from '../enums/status-code'
+
+export interface Notification {
+  message: string
+  statusCode: StatusCode
+}

--- a/src/app/shared/services/connection-error.service.spec.ts
+++ b/src/app/shared/services/connection-error.service.spec.ts
@@ -1,12 +1,11 @@
 import { ConnectionErrorService } from './connection-error.service'
 import { instance, mock } from '@typestrong/ts-mockito'
 import { ConnectionStatusObserver } from '../../core/services/connection-status-observer.service'
-import { MatSnackBar } from '@angular/material/snack-bar'
+import { NotificationService } from './notification.service'
 
 describe('ConnectionErrorService', () => {
   it('should be created', () => {
-    const mockedMatSnackBar = mock<MatSnackBar>()
     const mockedConnectionStatusObserver = mock<ConnectionStatusObserver>()
-    expect(new ConnectionErrorService(instance(mockedMatSnackBar), instance(mockedConnectionStatusObserver))).toBeTruthy()
+    expect(new ConnectionErrorService(instance(mock(NotificationService)), instance(mockedConnectionStatusObserver))).toBeTruthy()
   })
 })

--- a/src/app/shared/services/connection-error.service.ts
+++ b/src/app/shared/services/connection-error.service.ts
@@ -1,28 +1,20 @@
 import { Injectable, OnDestroy } from '@angular/core'
-import { MatSnackBar } from '@angular/material/snack-bar'
 import { ConnectionStatusObserver } from '../../core/services/connection-status-observer.service'
 import { EventSubscription } from '../../event-system/abstractions/event-observer.service'
+import { NotificationService } from './notification.service'
 
 @Injectable()
 export class ConnectionErrorService implements OnDestroy {
   private readonly subscriptions: EventSubscription[]
 
   constructor(
-    private readonly snackBar: MatSnackBar,
+    private readonly notificationService: NotificationService,
     private readonly connectionStatusObserver: ConnectionStatusObserver
   ) {
     this.subscriptions = [
-      this.connectionStatusObserver.subscribeToClosed(() => this.openDangerSnackBar($localize`:connection-error:Lost connection to backend. Attempting to reconnect...`)),
-      this.connectionStatusObserver.subscribeToReconnect(() => this.openSnackBar('Reconnected to backend.')),
+      this.connectionStatusObserver.subscribeToClosed(() => this.notificationService.createErrorNotification($localize`:connection-error:Lost connection to backend. Attempting to reconnect...`)),
+      this.connectionStatusObserver.subscribeToReconnect(() => this.notificationService.createInfoNotification('Reconnected to backend.')),
     ]
-  }
-
-  private openSnackBar(message: string): void {
-    this.snackBar.open(message, $localize`global.dismiss.label`, { panelClass: 'snackbar-success' })
-  }
-
-  private openDangerSnackBar(message: string): void {
-    this.snackBar.open(message, undefined, { panelClass: 'snackbar-danger', duration: 3000000 })
   }
 
   public ngOnDestroy(): void {

--- a/src/app/shared/services/http/http-error.service.spec.ts
+++ b/src/app/shared/services/http/http-error.service.spec.ts
@@ -1,5 +1,4 @@
 import { HttpErrorService } from './http-error.service'
-import { MatSnackBar } from '@angular/material/snack-bar'
 import { instance, mock } from '@typestrong/ts-mockito'
 import { TestLoggerFactory } from '../../../test/factories/test-logger.factory'
 import { Logger } from '../../../core/abstractions/logger.service'
@@ -7,8 +6,7 @@ import { NotificationService } from '../notification.service'
 
 describe('HttpErrorService', () => {
   it('should be created', () => {
-    const mockedMatSnackBar = mock<MatSnackBar>()
-    const testee = new HttpErrorService(instance(mockedMatSnackBar), instance(mock(NotificationService)), createLogger())
+    const testee = new HttpErrorService(instance(mock(NotificationService)), createLogger())
     expect(testee).toBeTruthy()
   })
 

--- a/src/app/shared/services/http/http-error.service.spec.ts
+++ b/src/app/shared/services/http/http-error.service.spec.ts
@@ -3,11 +3,12 @@ import { MatSnackBar } from '@angular/material/snack-bar'
 import { instance, mock } from '@typestrong/ts-mockito'
 import { TestLoggerFactory } from '../../../test/factories/test-logger.factory'
 import { Logger } from '../../../core/abstractions/logger.service'
+import { NotificationService } from '../notification.service'
 
 describe('HttpErrorService', () => {
   it('should be created', () => {
     const mockedMatSnackBar = mock<MatSnackBar>()
-    const testee = new HttpErrorService(instance(mockedMatSnackBar), createLogger())
+    const testee = new HttpErrorService(instance(mockedMatSnackBar), instance(mock(NotificationService)), createLogger())
     expect(testee).toBeTruthy()
   })
 

--- a/src/app/shared/services/http/http-error.service.ts
+++ b/src/app/shared/services/http/http-error.service.ts
@@ -3,17 +3,20 @@ import { MatSnackBar } from '@angular/material/snack-bar'
 import { HttpErrorResponse } from '@angular/common/http'
 import { EMPTY, Observable } from 'rxjs'
 import { Logger } from '../../../core/abstractions/logger.service'
+import { NotificationService } from '../notification.service'
 
 @Injectable()
 export class HttpErrorService {
   constructor(
     private readonly snackBar: MatSnackBar,
+    private readonly notificationService: NotificationService,
     private readonly logger: Logger
   ) {}
 
   public catchError(error: HttpErrorResponse): Observable<never> {
     this.logger.data(error).error('Caught Error:')
-    this.openSnackBarIfError(error)
+    this.notificationService.createNotification()
+    // this.openSnackBarIfError(error)
     return EMPTY
   }
 

--- a/src/app/shared/services/http/http-error.service.ts
+++ b/src/app/shared/services/http/http-error.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core'
-import { MatSnackBar } from '@angular/material/snack-bar'
 import { HttpErrorResponse } from '@angular/common/http'
 import { EMPTY, Observable } from 'rxjs'
 import { Logger } from '../../../core/abstractions/logger.service'
@@ -8,35 +7,27 @@ import { NotificationService } from '../notification.service'
 @Injectable()
 export class HttpErrorService {
   constructor(
-    private readonly snackBar: MatSnackBar,
     private readonly notificationService: NotificationService,
     private readonly logger: Logger
   ) {}
 
   public catchError(error: HttpErrorResponse): Observable<never> {
     this.logger.data(error).error('Caught Error:')
-    this.notificationService.createNotification()
-    // this.openSnackBarIfError(error)
+    this.createNotificationIfError(error)
     return EMPTY
   }
 
-  private openSnackBarIfError(error: HttpErrorResponse): void {
+  private createNotificationIfError(error: HttpErrorResponse): void {
+    if (error.status >= 500) {
+      this.notificationService.createErrorNotification(error.message)
+      return
+    }
+    if (error.status >= 300) {
+      this.notificationService.createWarningNotification(error.message)
+      return
+    }
     if (error.status >= 200 && error.status < 300) {
       return
     }
-    this.snackBar.open(error.error.message, $localize`global.dismiss.label`, {
-      panelClass: [this.getSnackBarCss(error.status)],
-    })
-  }
-
-  private getSnackBarCss(statusCode: number): string {
-    if (statusCode >= 500) {
-      return 'snackbar-danger'
-    }
-    if (statusCode >= 300) {
-      return 'snackbar-warning'
-    }
-    // Unknown status - using default CSS
-    return ''
   }
 }

--- a/src/app/shared/services/notification.service.ts
+++ b/src/app/shared/services/notification.service.ts
@@ -1,15 +1,27 @@
 import { Injectable } from '@angular/core'
 import { Observable, Subject } from 'rxjs'
+import { Notification } from '../models/notification'
+import { StatusCode } from '../enums/status-code'
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class NotificationService {
-  private readonly notificationSubject: Subject<void> = new Subject()
+  private readonly notificationSubject: Subject<Notification> = new Subject()
 
-  public createNotification(): void {
-    this.notificationSubject.next()
+  public createInfoNotification(message: string): void {
+    this.notificationSubject.next({ message, statusCode: StatusCode.GOOD })
   }
 
-  public subscribeToNotifications(): Observable<void> {
+  public createErrorNotification(message: string): void {
+    this.notificationSubject.next({ message, statusCode: StatusCode.BAD })
+  }
+
+  public createWarningNotification(message: string): void {
+    this.notificationSubject.next({ message, statusCode: StatusCode.WARNING })
+  }
+
+  public subscribeToNotifications(): Observable<Notification> {
     return this.notificationSubject.asObservable()
   }
 }

--- a/src/app/shared/services/notification.service.ts
+++ b/src/app/shared/services/notification.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core'
+import { Observable, Subject } from 'rxjs'
+
+@Injectable()
+export class NotificationService {
+  private readonly notificationSubject: Subject<void> = new Subject()
+
+  public createNotification(): void {
+    this.notificationSubject.next()
+  }
+
+  public subscribeToNotifications(): Observable<void> {
+    return this.notificationSubject.asObservable()
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core'
-import { MAT_SNACK_BAR_DEFAULT_OPTIONS, MatSnackBarModule } from '@angular/material/snack-bar'
 import { MatToolbarModule } from '@angular/material/toolbar'
 import { MatIconModule } from '@angular/material/icon'
 import { MatButtonModule } from '@angular/material/button'
@@ -61,7 +60,6 @@ import { HttpSystemInformationService } from './services/http/http-system-inform
 import { TooltipComponent } from './components/tooltip/tooltip.component'
 import { ConfigurationParser } from './abstractions/configuration-parser.service'
 import { ZodConfigurationParser } from './services/zod-configuration-parser.service'
-import { NotificationService } from './services/notification.service'
 import { NotificationContainerComponent } from './components/notification-container/notification-container.component'
 import { NotificationComponent } from './components/notification/notification.component'
 
@@ -91,7 +89,6 @@ import { NotificationComponent } from './components/notification/notification.co
   imports: [
     CommonModule,
     HttpClientModule,
-    MatSnackBarModule,
     MatToolbarModule,
     MatIconModule,
     MatButtonModule,
@@ -132,7 +129,6 @@ import { NotificationComponent } from './components/notification/notification.co
     NotificationContainerComponent,
   ],
   providers: [
-    { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { duration: 5000, verticalPosition: 'top' } },
     { provide: Logger, useClass: Tv2LoggerService },
     { provide: ActionService, useClass: HttpActionService },
     { provide: ActionTriggerService, useClass: HttpActionTriggerService },
@@ -153,7 +149,6 @@ import { NotificationComponent } from './components/notification/notification.co
     MediaStateService,
     RundownNavigationService,
     TimerPipe,
-    NotificationService,
   ],
 })
 export class SharedModule {}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -61,6 +61,9 @@ import { HttpSystemInformationService } from './services/http/http-system-inform
 import { TooltipComponent } from './components/tooltip/tooltip.component'
 import { ConfigurationParser } from './abstractions/configuration-parser.service'
 import { ZodConfigurationParser } from './services/zod-configuration-parser.service'
+import { NotificationService } from './services/notification.service'
+import { NotificationContainerComponent } from './components/notification-container/notification-container.component'
+import { NotificationComponent } from './components/notification/notification.component'
 
 @NgModule({
   declarations: [
@@ -82,6 +85,8 @@ import { ZodConfigurationParser } from './services/zod-configuration-parser.serv
     CustomCheckboxComponent,
     ButtonComponent,
     TooltipComponent,
+    NotificationContainerComponent,
+    NotificationComponent,
   ],
   imports: [
     CommonModule,
@@ -124,6 +129,7 @@ import { ZodConfigurationParser } from './services/zod-configuration-parser.serv
     FormsModule,
     ButtonComponent,
     TooltipComponent,
+    NotificationContainerComponent,
   ],
   providers: [
     { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { duration: 5000, verticalPosition: 'top' } },
@@ -147,6 +153,7 @@ import { ZodConfigurationParser } from './services/zod-configuration-parser.serv
     MediaStateService,
     RundownNavigationService,
     TimerPipe,
+    NotificationService,
   ],
 })
 export class SharedModule {}

--- a/src/scss/_sofie-color-vars.scss
+++ b/src/scss/_sofie-color-vars.scss
@@ -5,7 +5,8 @@ body {
   --light-gray-color: #f6f6f6;
   --gray-color: #cccccc;
   --dark-gray-color: #777777;
-  --black-color: #000000aa;
+  --black-color: #000000;
+  --black-color-with-alpha: #000000aa;
   --dark-color: #3a3a3a;
   --background-color: #343434;
   --green-color: green;

--- a/src/scss/_sofie-color-vars.scss
+++ b/src/scss/_sofie-color-vars.scss
@@ -5,7 +5,7 @@ body {
   --light-gray-color: #f6f6f6;
   --gray-color: #cccccc;
   --dark-gray-color: #777777;
-  --black-color: #000000;
+  --black-color: #000000aa;
   --dark-color: #3a3a3a;
   --background-color: #343434;
   --green-color: green;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -14,8 +14,7 @@
 html,
 body {
   height: 100%;
-  overflow-y: hidden;
-  overflow-x: auto;
+  overflow: hidden;
   min-width: 1100px;
 }
 


### PR DESCRIPTION
Our Snackbar has been replaced by a NotificationService.
When called, this service will notify all the NotificationContainers (useally one per page, but there can be as many as your heart desire) and they will create a Notification that will popup where the container is placed.

The NotificationService is able to be called from anywhere in the system.
To use the NotificationService, simply inject it and call one of it functions; Like so:
```
constructor(private notificationService: NotificationService) {
  this.notificationService.createInfoNotification('write-your-message-here')
}
``` 

The introduction of the NotificationServcie means that all references to MatSnackbar has been removed.

Demo:

https://github.com/tv2/ng-sofie/assets/23049647/ff8eb3c3-5adb-47f8-8dc1-f1592e953c13

