### PR TITLE
SOF-1822: Fix broken rundown view layout

### DIFF
--- a/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.html
+++ b/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.html
@@ -1,71 +1,73 @@
-<sofie-header #header></sofie-header>
-<sofie-notification-popup-container [topOffset]="header.elementRef.nativeElement.offsetHeight"></sofie-notification-popup-container>
+<sofie-header></sofie-header>
+<div class="rundown-overview-viewport">
+  <sofie-notification-popup-container></sofie-notification-popup-container>
 
-<h1 class="c-rundown-overview__title" i18n>rundown-overview.rundown-overview.title</h1>
+  <h1 class="c-rundown-overview__title" i18n>rundown-overview.rundown-overview.title</h1>
 
-<div *ngIf="isLoading; else doneLoading" class="c-rundown-overview__loading-rundowns">
-  <mat-card-title i18n>rundown-overview-component.rundown-overview.loading-rundowns.message</mat-card-title>
-</div>
-
-<ng-template #doneLoading>
-  <div *ngIf="basicRundowns.length === 0; else rundowns" class="c-rundown-overview__no-rundowns">
-    <h2 i18n>rundown-overview-component.no-rundowns-available.message</h2>
-    <p i18n>rundown-overview-component.check-connection-configure-ingest-gateway.message</p>
+  <div *ngIf="isLoading; else doneLoading" class="c-rundown-overview__loading-rundowns">
+    <mat-card-title i18n>rundown-overview-component.rundown-overview.loading-rundowns.message</mat-card-title>
   </div>
-</ng-template>
 
-<ng-template #rundowns>
-  <table *ngIf="!isLoading && basicRundowns.length > 0" mat-table [dataSource]="basicRundowns">
-    <ng-container matColumnDef="status">
-      <mat-header-cell *matHeaderCellDef></mat-header-cell>
-      <mat-cell *matCellDef="let basicRundown" >
-        <sofie-pulsating-dot *ngIf="basicRundown.isActive" [color]="Color.ON_AIR" [animationDurationSeconds]="3"></sofie-pulsating-dot>
-      </mat-cell>
-    </ng-container>
+  <ng-template #doneLoading>
+    <div *ngIf="basicRundowns.length === 0; else rundowns" class="c-rundown-overview__no-rundowns">
+      <h2 i18n>rundown-overview-component.no-rundowns-available.message</h2>
+      <p i18n>rundown-overview-component.check-connection-configure-ingest-gateway.message</p>
+    </div>
+  </ng-template>
 
-    <ng-container matColumnDef="name">
-      <mat-header-cell *matHeaderCellDef i18n>rundown-overview-component.rundown-label</mat-header-cell>
-      <mat-cell *matCellDef="let basicRundown" class="c-rundown-name" (click)="navigateToRundown(basicRundown)">
-        {{basicRundown.name}}
-      </mat-cell>
-    </ng-container>
+  <ng-template #rundowns>
+    <table *ngIf="!isLoading && basicRundowns.length > 0" mat-table [dataSource]="basicRundowns">
+      <ng-container matColumnDef="status">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let basicRundown" >
+          <sofie-pulsating-dot *ngIf="basicRundown.isActive" [color]="Color.ON_AIR" [animationDurationSeconds]="3"></sofie-pulsating-dot>
+        </mat-cell>
+      </ng-container>
 
-    <ng-container matColumnDef="plannedStart">
-      <mat-header-cell *matHeaderCellDef>Planned start</mat-header-cell>
-      <mat-cell *matCellDef="let basicRundown">
-        {{ getPlannedStart(basicRundown) ? (getPlannedStart(basicRundown) | date: 'HH:mm:ss') : 'Not set' }}
-      </mat-cell>
-    </ng-container>
+      <ng-container matColumnDef="name">
+        <mat-header-cell *matHeaderCellDef i18n>rundown-overview-component.rundown-label</mat-header-cell>
+        <mat-cell *matCellDef="let basicRundown" class="c-rundown-name" (click)="navigateToRundown(basicRundown)">
+          {{basicRundown.name}}
+        </mat-cell>
+      </ng-container>
 
-    <ng-container matColumnDef="duration">
-      <mat-header-cell *matHeaderCellDef>Duration</mat-header-cell>
-      <mat-cell *matCellDef="let basicRundown">
-        {{ getDurationInMs(basicRundown) ? (getDurationInMs(basicRundown)! | timer: 'HH:mm:ss') : 'Not set' }}
-      </mat-cell>
-    </ng-container>
+      <ng-container matColumnDef="plannedStart">
+        <mat-header-cell *matHeaderCellDef>Planned start</mat-header-cell>
+        <mat-cell *matCellDef="let basicRundown">
+          {{ getPlannedStart(basicRundown) ? (getPlannedStart(basicRundown) | date: 'HH:mm:ss') : 'Not set' }}
+        </mat-cell>
+      </ng-container>
 
-    <ng-container matColumnDef="plannedEnd">
-      <mat-header-cell *matHeaderCellDef>Planned end</mat-header-cell>
-      <mat-cell *matCellDef="let basicRundown">
-        {{ getPlannedEnd(basicRundown) ? (getPlannedEnd(basicRundown) | date: 'HH:mm:ss') : 'Not set' }}
-      </mat-cell>
-    </ng-container>
+      <ng-container matColumnDef="duration">
+        <mat-header-cell *matHeaderCellDef>Duration</mat-header-cell>
+        <mat-cell *matCellDef="let basicRundown">
+          {{ getDurationInMs(basicRundown) ? (getDurationInMs(basicRundown)! | timer: 'HH:mm:ss') : 'Not set' }}
+        </mat-cell>
+      </ng-container>
 
-    <ng-container matColumnDef="modifiedAt">
-      <mat-header-cell *matHeaderCellDef i18n>rundown-overview-component.last-updated.label</mat-header-cell>
-      <mat-cell *matCellDef="let basicRundown">
-        {{basicRundown.modifiedAt | date: 'HH:mm – d LLL YYYY'}}
-      </mat-cell>
-    </ng-container>
+      <ng-container matColumnDef="plannedEnd">
+        <mat-header-cell *matHeaderCellDef>Planned end</mat-header-cell>
+        <mat-cell *matCellDef="let basicRundown">
+          {{ getPlannedEnd(basicRundown) ? (getPlannedEnd(basicRundown) | date: 'HH:mm:ss') : 'Not set' }}
+        </mat-cell>
+      </ng-container>
 
-    <ng-container matColumnDef="delete">
-      <mat-header-cell *matHeaderCellDef></mat-header-cell>
-      <mat-cell class="c-delete-rundown-cell" *matCellDef="let basicRundown">
-        <sofie-icon-button class="material-icons c-delete-rundown-icon" [iconButton]="IconButton.TRASH_CAN" [iconButtonSize]="IconButtonSize.S" (click)="openDeletionDialog(basicRundown)"></sofie-icon-button>
-      </mat-cell>
-    </ng-container>
+      <ng-container matColumnDef="modifiedAt">
+        <mat-header-cell *matHeaderCellDef i18n>rundown-overview-component.last-updated.label</mat-header-cell>
+        <mat-cell *matCellDef="let basicRundown">
+          {{basicRundown.modifiedAt | date: 'HH:mm – d LLL YYYY'}}
+        </mat-cell>
+      </ng-container>
 
-    <mat-header-row *matHeaderRowDef="['status', 'name', 'plannedStart', 'duration', 'plannedEnd', 'modifiedAt', 'delete']"></mat-header-row>
-    <mat-row *matRowDef="let basicRundown; columns: ['status','name', 'plannedStart', 'duration', 'plannedEnd', 'modifiedAt', 'delete']"></mat-row>
-  </table>
-</ng-template>
+      <ng-container matColumnDef="delete">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell class="c-delete-rundown-cell" *matCellDef="let basicRundown">
+          <sofie-icon-button class="material-icons c-delete-rundown-icon" [iconButton]="IconButton.TRASH_CAN" [iconButtonSize]="IconButtonSize.S" (click)="openDeletionDialog(basicRundown)"></sofie-icon-button>
+        </mat-cell>
+      </ng-container>
+
+      <mat-header-row *matHeaderRowDef="['status', 'name', 'plannedStart', 'duration', 'plannedEnd', 'modifiedAt', 'delete']"></mat-header-row>
+      <mat-row *matRowDef="let basicRundown; columns: ['status','name', 'plannedStart', 'duration', 'plannedEnd', 'modifiedAt', 'delete']"></mat-row>
+    </table>
+  </ng-template>
+</div>

--- a/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.scss
+++ b/src/app/rundown-overview/components/rundown-overview/rundown-overview.component.scss
@@ -2,7 +2,14 @@
   display: block;
   max-height: 100vh;
   overflow: auto;
+
+  .rundown-overview-viewport {
+    position: relative;
+    height: 100%;
+    overflow: hidden;
+  }
 }
+
 .mat-table {
   padding: 0 3em;
   margin: 3em 0;

--- a/src/app/rundown-view/components/on-air-details-panel/on-air-details-panel.component.scss
+++ b/src/app/rundown-view/components/on-air-details-panel/on-air-details-panel.component.scss
@@ -44,4 +44,8 @@
       font-weight: bold;
     }
   }
+
+  sofie-notification-icon {
+    margin-right: 10px;
+  }
 }

--- a/src/app/rundown-view/components/rundown-view/rundown-view.component.html
+++ b/src/app/rundown-view/components/rundown-view/rundown-view.component.html
@@ -6,12 +6,14 @@
 
 <ng-template #rundownLoaded>
     <ng-container *ngIf="rundown; else rundownRemoved">
-        <sofie-rundown-header #header [rundown]="rundown"></sofie-rundown-header>
-        <sofie-on-air-details-panel #onAirDetails [rundown]="rundown"></sofie-on-air-details-panel>
-        <sofie-notification-popup-container *ngIf="shouldShowPopupNotifications" [topOffset]="header.elementRef.nativeElement.offsetHeight + onAirDetails.elementRef.nativeElement.offsetHeight"></sofie-notification-popup-container>
-        <div class="rundown-view-body">
-            <sofie-rundown [rundown]="rundown"></sofie-rundown>
-            <sofie-notification-panel></sofie-notification-panel>
+        <sofie-rundown-header [rundown]="rundown"></sofie-rundown-header>
+        <sofie-on-air-details-panel [rundown]="rundown"></sofie-on-air-details-panel>
+        <div class="rundown-viewport">
+            <sofie-notification-popup-container *ngIf="shouldShowPopupNotifications"></sofie-notification-popup-container>
+            <div class="rundown-viewport-body">
+              <sofie-rundown [rundown]="rundown"></sofie-rundown>
+              <sofie-notification-panel></sofie-notification-panel>
+            </div>
         </div>
         <sofie-draggable-shelf localStorageKey="producer-shelf">
             <sofie-producer-shelf

--- a/src/app/rundown-view/components/rundown-view/rundown-view.component.html
+++ b/src/app/rundown-view/components/rundown-view/rundown-view.component.html
@@ -9,11 +9,9 @@
         <sofie-rundown-header [rundown]="rundown"></sofie-rundown-header>
         <sofie-on-air-details-panel [rundown]="rundown"></sofie-on-air-details-panel>
         <div class="rundown-viewport">
-            <sofie-notification-popup-container *ngIf="shouldShowPopupNotifications"></sofie-notification-popup-container>
-            <div class="rundown-viewport-body">
-              <sofie-rundown [rundown]="rundown"></sofie-rundown>
-              <sofie-notification-panel></sofie-notification-panel>
-            </div>
+           <sofie-notification-popup-container *ngIf="shouldShowPopupNotifications"></sofie-notification-popup-container>
+           <sofie-rundown [rundown]="rundown"></sofie-rundown>
+           <sofie-notification-panel></sofie-notification-panel>
         </div>
         <sofie-draggable-shelf localStorageKey="producer-shelf">
             <sofie-producer-shelf

--- a/src/app/rundown-view/components/rundown-view/rundown-view.component.scss
+++ b/src/app/rundown-view/components/rundown-view/rundown-view.component.scss
@@ -34,13 +34,8 @@
   }
 
   .rundown-viewport {
-    position: relative;
-    height: 100%;
-    overflow: hidden;
-  }
-
-  .rundown-viewport-body {
     display: flex;
+    position: relative;
     height: 100%;
     overflow: hidden;
 

--- a/src/app/rundown-view/components/rundown-view/rundown-view.component.scss
+++ b/src/app/rundown-view/components/rundown-view/rundown-view.component.scss
@@ -23,6 +23,7 @@
     padding: 100px;
     color: var(--text-color);
   }
+
   .removed-rundown {
     text-align: center;
     background-color: var(--background-color);
@@ -31,9 +32,21 @@
     padding: 100px;
     color: var(--text-color);
   }
+
+  .rundown-viewport {
+    position: relative;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .rundown-viewport-body {
+    display: flex;
+    height: 100%;
+    overflow: hidden;
+
+    sofie-rundown {
+      flex: 1;
+    }
+  }
 }
 
-.rundown-view-body {
-  display: flex;
-  overflow: hidden;
-}

--- a/src/app/settings/components/settings/settings.component.html
+++ b/src/app/settings/components/settings/settings.component.html
@@ -1,7 +1,7 @@
-<sofie-header #header></sofie-header>
-<sofie-notification-popup-container [topOffset]="header.elementRef.nativeElement.offsetHeight"></sofie-notification-popup-container>
+<sofie-header></sofie-header>
 
 <div class="c-settings">
+  <sofie-notification-popup-container></sofie-notification-popup-container>
   <div class="c-settings__menu"><sofie-settings-menu></sofie-settings-menu></div>
   <div class="c-settings__content"><router-outlet></router-outlet></div>
 </div>

--- a/src/app/settings/components/settings/settings.component.scss
+++ b/src/app/settings/components/settings/settings.component.scss
@@ -1,4 +1,5 @@
 .c-settings {
+  position: relative;
   min-height: calc(100vh - 70px);
   border-top: 1px solid var(--white-color);
   display: flex;

--- a/src/app/shared/components/notification-icon/notification-icon.component.html
+++ b/src/app/shared/components/notification-icon/notification-icon.component.html
@@ -1,1 +1,1 @@
-<sofie-icon-button [ngClass]="{ error: hasNotification() }" [iconButton]="IconButton.CIRCLE_EXCLAMATION" [iconButtonSize]="IconButtonSize.XXL" (click)="toggleNotificationPanel()"></sofie-icon-button>
+<sofie-icon-button [ngClass]="{ error: hasNotification() }" [iconButton]="IconButton.CIRCLE_EXCLAMATION" [iconButtonSize]="IconButtonSize.XL" (click)="toggleNotificationPanel()"></sofie-icon-button>

--- a/src/app/shared/components/notification-icon/notification-icon.component.scss
+++ b/src/app/shared/components/notification-icon/notification-icon.component.scss
@@ -6,6 +6,7 @@
 
   sofie-icon-button {
     color: var(--dark-gray-color);
+    transition: color .2s;
 
     &.error {
       color: var(--danger-color);

--- a/src/app/shared/components/notification-popup-container/notification-popup-container.component.scss
+++ b/src/app/shared/components/notification-popup-container/notification-popup-container.component.scss
@@ -1,4 +1,5 @@
 :host {
   position: absolute;
   width: 400px;
+  z-index: 300;
 }


### PR DESCRIPTION
The PR fixes the rundown view layout for small rundowns, that prior to this, would have the notifications panel fill up to half the width, and places notifications above timeline flags. The changes also make use of "viewport" elements to specify the position of notifications rather than page-relative absolute positions.