### PR TITLE
fix: Remove deprecated SelectedGfxSetupName attribute from showstyle configuration type.

### DIFF
--- a/src/app/core/models/show-style-variant.ts
+++ b/src/app/core/models/show-style-variant.ts
@@ -1,8 +1,4 @@
 export interface ShowStyleVariantBlueprintConfiguration {
-  SelectedGfxSetupName: {
-    value: string
-    label: string
-  }
   GfxDefaults: {
     id?: string
     DefaultSetupName: {

--- a/src/app/core/parsers/zod-entity-parser.service.ts
+++ b/src/app/core/parsers/zod-entity-parser.service.ts
@@ -20,10 +20,6 @@ import { StatusCode } from '../../shared/enums/status-code'
 
 export class ZodEntityParser implements EntityParser {
   private readonly blueprintConfigurationParser = zod.object({
-    SelectedGfxSetupName: zod.object({
-      value: zod.string(),
-      label: zod.string(),
-    }),
     GfxDefaults: zod
       .object({
         id: zod.optional(zod.string()),


### PR DESCRIPTION
`SelectedGfxSetupName` is superseded by `GfxDefaults`.