### PR TITLE
fix: MiniShelf media duration updates correctly

### DIFF
--- a/src/app/rundown-view/components/mini-shelf/mini-shelf.component.ts
+++ b/src/app/rundown-view/components/mini-shelf/mini-shelf.component.ts
@@ -39,8 +39,8 @@ export class MiniShelfComponent implements OnInit, OnDestroy, OnChanges {
   public ngOnInit(): void {
     this.configurationServiceSubscription = this.configurationService.getStudioConfiguration().subscribe((studioConfiguration: StudioConfiguration) => {
       this.studioConfiguration = studioConfiguration
+      this.updateMediaAndCalculate()
     })
-    this.updateMediaAndCalculate()
 
     this.rundownStateService.subscribeToOnAirPart(this.segment.rundownId).subscribe(onAirPart => {
       const onAirTv2Part: Tv2Part | undefined = onAirPart as Tv2Part | undefined


### PR DESCRIPTION
We were unable to see the hover scrub time due to the fact that we do not set the `mediaDurationInMsWithoutPostroll` unless we have our `studioConfiguration`. 