### PR TITLE
Fix/unstable tooltip trigger element

### DIFF
--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
@@ -11,7 +11,7 @@
       </header>
 
       <div *ngIf="isMediaUnavailable" class="source-unavailable-banner">
-          <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
+        <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
         <span i18n>piece-tooltip.source-unavailable.label</span>
       </div>
 

--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
@@ -12,7 +12,7 @@
 
       <div *ngIf="isMediaUnavailable" class="source-unavailable-banner">
         <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
-        <span i18n>piece-tooltip.source-unavailable.label</span>
+        <span class="ms-1" i18n>piece-tooltip.source-unavailable.label</span>
       </div>
 
       <div class="content-fields">

--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.scss
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.scss
@@ -27,10 +27,6 @@
     sofie-icon-button {
       color: var(--black-color);
     }
-
-    span {
-      margin-left: 4px;
-    }
   }
 
   .content-fields {

--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.scss
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.scss
@@ -27,6 +27,10 @@
     sofie-icon-button {
       color: var(--black-color);
     }
+
+    span {
+      margin-left: 4px;
+    }
   }
 
   .content-fields {

--- a/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="previewUrl.length > 0">
     <video #videoElementRef [src]="previewUrl"></video>
     <div class="time-code">
-        <span *ngIf="currentVideoTimeInMs > 0">{{ currentVideoTimeInMs | timer: 'HH?:mm:ss' }}</span>
+        <span *ngIf="positionInVideoInMs > 0">{{ positionInVideoInMs | timer: 'HH?:mm:ss' }}</span>
     </div>
 </ng-container>

--- a/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.ts
+++ b/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.ts
@@ -14,8 +14,6 @@ export class VideoHoverScrubComponent implements OnInit, OnDestroy, OnChanges {
   @Input() public isJingle?: boolean
   @Input() public positionInVideoInMs: number
 
-  public currentVideoTimeInMs: number
-
   @ViewChild('videoElementRef')
   public videoElementRef: ElementRef<HTMLVideoElement>
 

--- a/src/app/shared/directives/tooltip.directive.ts
+++ b/src/app/shared/directives/tooltip.directive.ts
@@ -19,7 +19,7 @@ export class TooltipDirective implements OnDestroy {
 
   constructor(
     private readonly applicationRef: ApplicationRef,
-    private readonly triggerElementRef: ElementRef
+    private readonly elementRef: ElementRef
   ) {}
 
   @HostListener('mouseenter', ['$event'])
@@ -45,7 +45,7 @@ export class TooltipDirective implements OnDestroy {
       return
     }
 
-    const verticalPositionInPixels: number = this.triggerElementRef.nativeElement.getBoundingClientRect().top
+    const verticalPositionInPixels: number = this.elementRef.nativeElement.getBoundingClientRect().top
     const tooltipWidthInPixels: number = this.tooltipComponentRef.instance.getWidthInPixels()
 
     const horizontalOffsetInPixels: number = Math.max(event.clientX - Math.ceil(tooltipWidthInPixels / 2), MINIMUM_HORIZONTAL_OFFSET_IN_PIXELS)

--- a/src/app/shared/directives/tooltip.directive.ts
+++ b/src/app/shared/directives/tooltip.directive.ts
@@ -45,7 +45,7 @@ export class TooltipDirective implements OnDestroy {
       return
     }
 
-    const verticalPositionInPixels: number = this.triggerElementRef.nativeElement.getBoundingClientRect().top ?? 0
+    const verticalPositionInPixels: number = this.triggerElementRef.nativeElement.getBoundingClientRect().top
     const tooltipWidthInPixels: number = this.tooltipComponentRef.instance.getWidthInPixels()
 
     const horizontalOffsetInPixels: number = Math.max(event.clientX - Math.ceil(tooltipWidthInPixels / 2), MINIMUM_HORIZONTAL_OFFSET_IN_PIXELS)

--- a/src/app/shared/directives/tooltip.directive.ts
+++ b/src/app/shared/directives/tooltip.directive.ts
@@ -1,16 +1,4 @@
-import {
-  ApplicationRef,
-  ComponentRef,
-  createComponent,
-  Directive,
-  ElementRef,
-  EventEmitter,
-  HostListener,
-  Input,
-  OnDestroy,
-  Output,
-  TemplateRef
-} from '@angular/core'
+import { ApplicationRef, ComponentRef, createComponent, Directive, ElementRef, EventEmitter, HostListener, Input, OnDestroy, Output, TemplateRef } from '@angular/core'
 import { TooltipComponent } from '../components/tooltip/tooltip.component'
 
 const MINIMUM_HORIZONTAL_OFFSET_IN_PIXELS: number = 0
@@ -31,7 +19,7 @@ export class TooltipDirective implements OnDestroy {
 
   constructor(
     private readonly applicationRef: ApplicationRef,
-    private readonly triggerElement: ElementRef
+    private readonly triggerElementRef: ElementRef
   ) {}
 
   @HostListener('mouseenter', ['$event'])
@@ -57,7 +45,7 @@ export class TooltipDirective implements OnDestroy {
       return
     }
 
-    const verticalPositionInPixels: number = this.triggerElement.nativeElement.getBoundingClientRect().top ?? 0
+    const verticalPositionInPixels: number = this.triggerElementRef.nativeElement.getBoundingClientRect().top ?? 0
     const tooltipWidthInPixels: number = this.tooltipComponentRef.instance.getWidthInPixels()
 
     const horizontalOffsetInPixels: number = Math.max(event.clientX - Math.ceil(tooltipWidthInPixels / 2), MINIMUM_HORIZONTAL_OFFSET_IN_PIXELS)

--- a/src/app/shared/directives/tooltip.directive.ts
+++ b/src/app/shared/directives/tooltip.directive.ts
@@ -1,4 +1,16 @@
-import { ApplicationRef, ComponentRef, createComponent, Directive, EventEmitter, HostListener, Input, OnDestroy, Output, TemplateRef } from '@angular/core'
+import {
+  ApplicationRef,
+  ComponentRef,
+  createComponent,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnDestroy,
+  Output,
+  TemplateRef
+} from '@angular/core'
 import { TooltipComponent } from '../components/tooltip/tooltip.component'
 
 const MINIMUM_HORIZONTAL_OFFSET_IN_PIXELS: number = 0
@@ -17,7 +29,10 @@ export class TooltipDirective implements OnDestroy {
 
   private tooltipComponentRef: ComponentRef<TooltipComponent>
 
-  constructor(private readonly applicationRef: ApplicationRef) {}
+  constructor(
+    private readonly applicationRef: ApplicationRef,
+    private readonly triggerElement: ElementRef
+  ) {}
 
   @HostListener('mouseenter', ['$event'])
   public showTooltip(event: MouseEvent): void {
@@ -42,8 +57,7 @@ export class TooltipDirective implements OnDestroy {
       return
     }
 
-    const triggerElement: HTMLElement | null = event.target as HTMLElement | null
-    const verticalPositionInPixels: number = triggerElement?.getBoundingClientRect().top ?? 0
+    const verticalPositionInPixels: number = this.triggerElement.nativeElement.getBoundingClientRect().top ?? 0
     const tooltipWidthInPixels: number = this.tooltipComponentRef.instance.getWidthInPixels()
 
     const horizontalOffsetInPixels: number = Math.max(event.clientX - Math.ceil(tooltipWidthInPixels / 2), MINIMUM_HORIZONTAL_OFFSET_IN_PIXELS)


### PR DESCRIPTION
The tooltip position was based on the emitted mouse event, which would cause it to use the sub elements instead of the element with the tooltip directive.
By using the `ElementRef` as position reference, the position becomes stable.

A tiny bit of spacing between the triangle icon and the label has been added:
![Skærmbillede 2024-03-25 kl  15 17 45](https://github.com/tv2/ng-sofie/assets/11258272/0a7284e7-41d2-4e59-afec-961c6dfb7eb4)

Also fixs video hover scrub not showing time code.