### PR TITLE
Fix: Jingle hover scrub not working

### DIFF
--- a/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.html
+++ b/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.html
@@ -2,7 +2,7 @@
   class="piece"
   [style.width.px]="widthInPixels"
   [ngClass]="pieceTypeModifierClass"
-  [class.media-unavailable]="isMediaUnavailable"
+  [class.media-unavailable]="isMediaUnavailable()"
   sofieTooltip
   [sofieTooltipTemplate]="pieceTooltip"
   (tooltipMetadataChange)="updatePositionInVideo($event)"
@@ -16,7 +16,6 @@
     <sofie-piece-tooltip
             [piece]="piece"
             [durationInMs]="partDuration"
-            [isMediaUnavailable]="isMediaUnavailable"
             [media]="media"
             [positionInVideoInMs]="positionInVideoInMs"
     >

--- a/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.ts
+++ b/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.ts
@@ -136,7 +136,7 @@ export class OffsetablePieceComponent implements OnChanges, OnDestroy {
     return [piece.metadata.type.toLowerCase().replace(/_/g, '-'), (piece.metadata.audioMode ?? Tv2AudioMode.FULL).toLowerCase().replace('_', '-')].join(' ')
   }
 
-  public get isMediaUnavailable(): boolean {
+  public isMediaUnavailable(): boolean {
     return !!this.mediaSubscription && !this.media
   }
 

--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
@@ -1,8 +1,9 @@
 <div class="tooltip" *ngIf="tooltipContentFields.length > 0">
-  <sofie-video-hover-scrub *ngIf="shouldShowHoverScrub && !isMediaUnavailable"
-                           [filename]="media?.sourceName ?? piece.name"
-                           [positionInVideoInMs]="positionInVideoInMs"
-                           [isJingle]="tv2PieceType === Tv2PieceType.JINGLE">
+  <sofie-video-hover-scrub
+    *ngIf="shouldShowHoverScrub && media"
+    [filename]="media.sourceName"
+    [positionInVideoInMs]="positionInVideoInMs"
+  >
   </sofie-video-hover-scrub>
 
   <div class="tooltip-body">
@@ -10,7 +11,7 @@
           <span class="label">{{piece.name}}</span>
       </header>
 
-      <div *ngIf="isMediaUnavailable" class="source-unavailable-banner">
+      <div *ngIf="hasPieceMedia() && !media" class="source-unavailable-banner">
         <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
         <span class="ms-1" i18n>piece-tooltip.source-unavailable.label</span>
       </div>

--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.ts
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.ts
@@ -16,15 +16,13 @@ export class PieceTooltipComponent implements OnChanges {
   protected readonly Icon = Icon
   protected readonly IconSize = IconSize
 
-  @Input() public isMediaUnavailable?: boolean
   @Input() public piece: Piece
-  @Input() public durationInMs: number
   @Input() public media?: Media
+  @Input() public durationInMs: number
   @Input() public positionInVideoInMs: number = 0
 
   public tooltipContentFields: TooltipContentField[]
-  public Tv2PieceType = Tv2PieceType
-  public shouldShowHoverScrub: boolean
+  public shouldShowHoverScrub: boolean = false
 
   constructor(private readonly tv2PieceTooltipContentFieldService: Tv2PieceTooltipContentFieldService) {}
 
@@ -37,18 +35,18 @@ export class PieceTooltipComponent implements OnChanges {
     }
   }
 
-  public get tv2PieceType(): Tv2PieceType {
-    const piece: Tv2Piece = this.piece as Tv2Piece
-    return piece.metadata.type
-  }
-
   public updateTooltipContent(): void {
     this.tooltipContentFields = this.tv2PieceTooltipContentFieldService.getTooltipContentForPiece(this.piece, this.media, this.durationInMs)
   }
 
   public updateShouldShowHoverScrub(): void {
     const tv2Piece: Tv2Piece = this.piece as Tv2Piece
-    this.shouldShowHoverScrub = (tv2Piece.metadata?.type === Tv2PieceType.VIDEO_CLIP || tv2Piece.metadata?.type === Tv2PieceType.JINGLE) && tv2Piece.metadata.sourceName !== undefined
+    this.shouldShowHoverScrub = this.hasPieceMedia() && [Tv2PieceType.VIDEO_CLIP, Tv2PieceType.JINGLE].includes(tv2Piece.metadata.type)
+  }
+
+  public hasPieceMedia(): boolean {
+    const tv2Piece: Tv2Piece = this.piece as Tv2Piece
+    return tv2Piece.metadata.sourceName !== undefined
   }
 
   public getPieceColorClass(): string {

--- a/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="previewUrl.length > 0">
     <video #videoElementRef [src]="previewUrl"></video>
     <div class="time-code">
-        <span *ngIf="positionInVideoInMs > 0">{{ positionInVideoInMs | timer: 'HH?:mm:ss' }}</span>
+        <span>{{ positionInVideoInMs | timer: 'HH?:mm:ss' }}</span>
     </div>
 </ng-container>

--- a/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.spec.ts
+++ b/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.spec.ts
@@ -28,7 +28,7 @@ describe('VideoHoverScrubComponent', () => {
 
 function createMockOfConfigurationService(): ConfigurationService {
   const mockedConfigurationService = mock<ConfigurationService>()
-  const mockedObservable: Observable<StudioConfiguration> = of({ settings: { mediaPreviewUrl: '' }, blueprintConfiguration: { ServerPostrollDuration: 0, JingleFolder: '' } })
+  const mockedObservable: Observable<StudioConfiguration> = of({ settings: { mediaPreviewUrl: '' }, blueprintConfiguration: { ServerPostrollDuration: 0 } })
   when(mockedConfigurationService.getStudioConfiguration()).thenReturn(mockedObservable)
   return mockedConfigurationService
 }

--- a/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.ts
+++ b/src/app/rundown-view/components/rundown-tooltips/video-hover-scrub/video-hover-scrub.component.ts
@@ -10,8 +10,7 @@ import { Icon, IconSize } from 'src/app/shared/enums/icon'
   styleUrls: ['./video-hover-scrub.component.scss'],
 })
 export class VideoHoverScrubComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() public filename: string
-  @Input() public isJingle?: boolean
+  @Input() public filename: string = ''
   @Input() public positionInVideoInMs: number
 
   @ViewChild('videoElementRef')
@@ -38,7 +37,7 @@ export class VideoHoverScrubComponent implements OnInit, OnDestroy, OnChanges {
 
   private setVideoPreviewUrl(studioConfiguration: StudioConfiguration): void {
     const baseMediaUrl: string = `${studioConfiguration.settings.mediaPreviewUrl}/media/preview/`
-    this.previewUrl = this.isJingle ? `${baseMediaUrl}${studioConfiguration.blueprintConfiguration.JingleFolder}/${this.filename}` : `${baseMediaUrl}${this.filename}`
+    this.previewUrl = `${baseMediaUrl}${this.filename}`
     this.changeDetectorRef.detectChanges()
   }
 

--- a/src/app/shared/directives/tooltip.directive.ts
+++ b/src/app/shared/directives/tooltip.directive.ts
@@ -57,7 +57,7 @@ export class TooltipDirective implements OnDestroy {
     this.tooltipComponentRef.changeDetectorRef.detectChanges()
 
     this.tooltipMetadataChange.emit({
-      horizontalOffsetInPixels: event.offsetX,
+      horizontalOffsetInPixels: Math.max(event.offsetX, 0),
     })
   }
 

--- a/src/app/shared/directives/tooltip.directive.ts
+++ b/src/app/shared/directives/tooltip.directive.ts
@@ -2,6 +2,7 @@ import { ApplicationRef, ComponentRef, createComponent, Directive, ElementRef, E
 import { TooltipComponent } from '../components/tooltip/tooltip.component'
 
 const MINIMUM_HORIZONTAL_OFFSET_IN_PIXELS: number = 0
+const TOOLTIP_DISTANCE_FROM_ELEMENT_TOP_IN_PIXELS: number = 4
 
 export interface TooltipMetadata {
   horizontalOffsetInPixels: number
@@ -52,7 +53,7 @@ export class TooltipDirective implements OnDestroy {
     const maxHorizontalOffsetInPixes: number = window.innerWidth - tooltipWidthInPixels
     const leftPositionInPixels: number = Math.min(horizontalOffsetInPixels, maxHorizontalOffsetInPixes)
 
-    this.tooltipComponentRef.instance.topPositionInPixels = verticalPositionInPixels
+    this.tooltipComponentRef.instance.topPositionInPixels = verticalPositionInPixels - TOOLTIP_DISTANCE_FROM_ELEMENT_TOP_IN_PIXELS
     this.tooltipComponentRef.instance.leftPositionInPixels = leftPositionInPixels
     this.tooltipComponentRef.changeDetectorRef.detectChanges()
 

--- a/src/app/shared/models/studio-configuration.ts
+++ b/src/app/shared/models/studio-configuration.ts
@@ -1,6 +1,5 @@
 interface BlueprintConfiguration {
   ServerPostrollDuration: number
-  JingleFolder: string
 }
 
 interface StudioSettings {

--- a/src/app/test/factories/test-entity.factory.ts
+++ b/src/app/test/factories/test-entity.factory.ts
@@ -155,7 +155,6 @@ export class TestEntityFactory {
         mediaPreviewUrl: 'http://media.preview.url',
       },
       blueprintConfiguration: {
-        JingleFolder: 'jingle-folder',
         ServerPostrollDuration: 4200,
       },
       ...studioConfiguration,


### PR DESCRIPTION
Media source name for jingles contains the `JingleFolder` value, so the PR removes the JingleFolder.
Minor visual fixes have been applied to the hover scrub flow.