### PR TITLE
SOF-1836 - fix child alignment in card header

### DIFF
--- a/src/app/shared/components/card/card.component.scss
+++ b/src/app/shared/components/card/card.component.scss
@@ -7,5 +7,6 @@
   & > header {
     display: flex;
     justify-content: space-between;
+    align-items: center;
   }
 }

--- a/src/app/shared/components/text-input/text-input.component.html
+++ b/src/app/shared/components/text-input/text-input.component.html
@@ -1,5 +1,5 @@
 <div class="pt-2 pb-2">
-    <span class="mb-1">
+    <span *ngIf="label || helpText" class="mb-1">
         <label *ngIf="label">{{ label }}</label>
         <sofie-icon-button *ngIf="helpText" [tooltip]="helpText" [icon]="Icon.CIRCLE_QUESTION" [iconSize]="IconSize.M"></sofie-icon-button>
     </span>


### PR DESCRIPTION
- add center alignment for card header elements
- fix -  remove div content for text input if we don't have label or helpText