### PR TITLE
SOF-1881: Notification count not vertically centered

### DIFF
--- a/src/app/shared/components/notification-icon/notification-icon.component.scss
+++ b/src/app/shared/components/notification-icon/notification-icon.component.scss
@@ -17,7 +17,7 @@
       display: inline-block;
       min-width: 20px;
       height: 20px;
-      padding: 2px;
+      padding: 1px;
       border-radius: 10px;
       margin-left: -10px;
       margin-top: -15px;


### PR DESCRIPTION
Text size and padding was too big for the notification count circle. The padding has been reduced by 1px to have it fit.