### PR TITLE
SOF-1887 - Dont Require Name for Rundowns

### DIFF
--- a/src/app/core/parsers/zod-entity-parser.service.ts
+++ b/src/app/core/parsers/zod-entity-parser.service.ts
@@ -112,7 +112,7 @@ export class ZodEntityParser implements EntityParser {
 
   private readonly basicRundownParser = zod.object({
     id: zod.string().min(1),
-    name: zod.string().min(1),
+    name: zod.string(),
     mode: zod.nativeEnum(RundownMode),
     modifiedAt: zod.number(),
     timing: zod


### PR DESCRIPTION
The zod validation no longer requires a name for the rundown, in the edgecase where we have a "Ghost rundown", which was attained in Staging, we should be able to delete it just like in Core. 