### PR TITLE
SOF-1974: Display physical keys and shortcuts on virtual keyboard

### DIFF
--- a/src/app/producer-shelf/components/tv2-action-panel/tv2-action-panel.component.scss
+++ b/src/app/producer-shelf/components/tv2-action-panel/tv2-action-panel.component.scss
@@ -37,6 +37,7 @@
       width: 20px;
       background: var(--action-panel-scrollable-before-linear-gradient);
       pointer-events: none;
+      z-index: 2;
     }
 
     &::after {
@@ -49,6 +50,7 @@
       width: 20px;
       background: var(--action-panel-scrollable-after-linear-gradient);
       pointer-events: none;
+      z-index: 2;
     }
 
     .actions {

--- a/src/app/rundown-view/services/action-trigger-producer-key-binding.service.ts
+++ b/src/app/rundown-view/services/action-trigger-producer-key-binding.service.ts
@@ -145,6 +145,7 @@ export class ActionTriggerProducerKeyBindingService implements KeyBindingService
   private createBinding(action: Tv2Action, actionTrigger: ActionTrigger<KeyboardTriggerData>, rundownId: string): StyledKeyBinding {
     return {
       keys: actionTrigger.data.keys,
+      mappedKeys: actionTrigger.data.mappedToKeys,
       label: this.getActionTriggerLabel(actionTrigger, action),
       onMatched: () => this.actionService.executeAction(action.id, rundownId, actionTrigger.data.actionArguments).subscribe(),
       shouldMatchOnKeyRelease: true,


### PR DESCRIPTION
`StyledKeyBinding.mappedKeys` are now populated with data from `ActionTrigger<KeyboardTriggerData>.data.keys` to show the physical keys in the virtual keyboard.

This only displays the keyboard mappings for the physical keys, but does not add the functionality to a physical key binding for triggering the assigned action. Clicking the key on the virtual keyboard does trigger the action.

When AutoHotKey maps the physical keys to the shortcut keys registered in Sofie, the modifier layer of the shortcut will be displayed – not for the physical keys.

Boy scouting: The action panel gradients are no longer below the action labels.