### PR TITLE
Sof 1979/show invalid segments as invalid

### DIFF
--- a/src/app/core/models/invalidity.ts
+++ b/src/app/core/models/invalidity.ts
@@ -1,0 +1,3 @@
+export interface Invalidity {
+  reason: string
+}

--- a/src/app/core/models/invalidity.ts
+++ b/src/app/core/models/invalidity.ts
@@ -1,3 +1,3 @@
 export interface Invalidity {
-  reason: string
+  readonly reason: string
 }

--- a/src/app/core/models/segment.ts
+++ b/src/app/core/models/segment.ts
@@ -1,5 +1,6 @@
 import { Part } from './part'
 import { Tv2SegmentMetadata } from './tv2-segment-metadata'
+import { Invalidity } from './invalidity'
 
 export interface Segment {
   readonly id: string
@@ -16,4 +17,5 @@ export interface Segment {
   readonly expectedDurationInMs?: number
   readonly executedAtEpochTime?: number
   readonly metadata?: Tv2SegmentMetadata
+  readonly invalidity?: Invalidity
 }

--- a/src/app/core/parsers/zod-entity-parser.service.ts
+++ b/src/app/core/parsers/zod-entity-parser.service.ts
@@ -109,6 +109,7 @@ export class ZodEntityParser implements EntityParser {
         miniShelfVideoClipFile: zod.string().optional(),
       })
       .optional(),
+    invalidity: zod.object({ reason: zod.string() }).optional(),
   })
 
   private readonly basicRundownParser = zod.object({

--- a/src/app/rundown-view/components/invalid-segment/invalid-segment.component.html
+++ b/src/app/rundown-view/components/invalid-segment/invalid-segment.component.html
@@ -1,0 +1,19 @@
+<div class="invalid-segment ms-4 me-4 mt-1 mb-2">
+    <div class="header">
+        <div class="header-toolbar">
+          <span class="reference-tag">
+            {{segment.referenceTag}}
+          </span>
+        </div>
+        <div class="invalid p-2 pt-1 pb-1">
+            <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
+            <span class="ms-1">INVALID</span>
+        </div>
+        <div class="title m-2">
+            {{ segment.name }}
+        </div>
+        <div class="text m-2">
+            {{ segment.invalidity?.reason }}
+        </div>
+    </div>
+</div>

--- a/src/app/rundown-view/components/invalid-segment/invalid-segment.component.html
+++ b/src/app/rundown-view/components/invalid-segment/invalid-segment.component.html
@@ -2,18 +2,18 @@
     <div class="header">
         <div class="header-toolbar">
           <span class="reference-tag">
-            {{segment.referenceTag}}
+            {{ segment.referenceTag }}
           </span>
         </div>
         <div class="invalid p-2 pt-1 pb-1">
-            <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
+            <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M" [disabled]="true"></sofie-icon-button>
             <span class="ms-1">INVALID</span>
+            <div class="text">
+                {{ segment.invalidity?.reason }}
+            </div>
         </div>
         <div class="title m-2">
             {{ segment.name }}
-        </div>
-        <div class="text m-2">
-            {{ segment.invalidity?.reason }}
         </div>
     </div>
 </div>

--- a/src/app/rundown-view/components/invalid-segment/invalid-segment.component.scss
+++ b/src/app/rundown-view/components/invalid-segment/invalid-segment.component.scss
@@ -1,0 +1,55 @@
+.invalid-segment {
+  display: flex;
+  overflow: hidden;
+  border-radius: 10px;
+  box-shadow: 0 2px 2px 2px var(--gradient-black-rgba-with-02-opacity-color);
+  --toolbar-height: 30px;
+
+  background: var(--black-color);
+  width: 270px;
+
+  .header {
+    flex: 0;
+    min-width: 270px;
+    background-color: var(--rundown-segment-header-background-color);
+    color: var(--text-color);
+    transition: background-color 0.2s;
+
+    .header-toolbar {
+      display: flex;
+      justify-content: space-between;
+      height: var(--toolbar-height);
+      background: var(--black-color);
+      padding: 6px;
+
+      .reference-tag {
+        flex: 1;
+      }
+    }
+
+    .invalid {
+      background: var(--attention-color);
+      color: var(--black-color);
+      font-size: 1rem;
+      font-weight: 500;
+
+      sofie-icon-button {
+        color: var(--black-color);
+      }
+    }
+
+    .title {
+      color: var(--text-color);
+      font-size: 1.4em;
+      font-weight: normal;
+      word-break: break-word;
+    }
+
+    .text {
+      color: var(--text-color);
+      font-size: 0.85em;
+      font-weight: normal;
+      word-break: break-word;
+    }
+  }
+}

--- a/src/app/rundown-view/components/invalid-segment/invalid-segment.component.scss
+++ b/src/app/rundown-view/components/invalid-segment/invalid-segment.component.scss
@@ -46,7 +46,6 @@
     }
 
     .text {
-      color: var(--text-color);
       font-size: 0.85em;
       font-weight: normal;
       word-break: break-word;

--- a/src/app/rundown-view/components/invalid-segment/invalid-segment.component.ts
+++ b/src/app/rundown-view/components/invalid-segment/invalid-segment.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core'
+import { Segment } from '../../../core/models/segment'
+import { Icon, IconSize } from '../../../shared/enums/icon'
+
+@Component({
+  selector: 'sofie-invalid-segment',
+  templateUrl: './invalid-segment.component.html',
+  styleUrls: ['invalid-segment.component.scss'],
+})
+export class InvalidSegmentComponent {
+  protected readonly Icon = Icon
+  protected readonly IconSize = IconSize
+
+  @Input()
+  public segment: Segment
+}

--- a/src/app/rundown-view/components/rundown/rundown.component.html
+++ b/src/app/rundown-view/components/rundown/rundown.component.html
@@ -1,20 +1,26 @@
 <div class="segments">
     <ng-container #segmentList *ngFor="let segment of rundown?.segments; trackBy: trackSegment">
-        <sofie-segment
-                class="segment"
-                [attr.data-segment-id]="segment.id"
-                *ngIf="!segment.isHidden"
-                [segment]="segment"
-                [isRundownActiveOrRehearsal]="isActiveOrRehearsal"
-                [isAutoNextStarted]="isAutoNextStarted"
-                [durationInMsUntilSegmentIsPutOnAir]="startOffsetsInMsFromPlayheadForSegments[segment.id]"
-                [remainingDurationInMsForOnAirPart]="remainingDurationInMsForOnAirPart"
-                [currentEpochTime]="currentEpochTime"
-        ></sofie-segment>
-        <sofie-mini-shelf
-                *ngIf="segment.metadata?.miniShelfVideoClipFile"
-                [segment]="segment"
-                [videoClipAction]="miniShelfSegmentActionMappings[segment.id]"
-        ></sofie-mini-shelf>
+        <sofie-invalid-segment *ngIf="segment.invalidity; else miniShelfTemplate" [segment]="segment">
+        </sofie-invalid-segment>
+        <ng-template #miniShelfTemplate>
+            <sofie-mini-shelf
+                    *ngIf="segment.metadata?.miniShelfVideoClipFile; else segmentTemplate"
+                    [segment]="segment"
+                    [videoClipAction]="miniShelfSegmentActionMappings[segment.id]"
+            ></sofie-mini-shelf>
+        </ng-template>
+        <ng-template #segmentTemplate>
+            <sofie-segment
+                    *ngIf="!segment.isHidden"
+                    [attr.data-segment-id]="segment.id"
+                    [segment]="segment"
+                    [isRundownActiveOrRehearsal]="isActiveOrRehearsal"
+                    [isAutoNextStarted]="isAutoNextStarted"
+                    [durationInMsUntilSegmentIsPutOnAir]="startOffsetsInMsFromPlayheadForSegments[segment.id]"
+                    [remainingDurationInMsForOnAirPart]="remainingDurationInMsForOnAirPart"
+                    [currentEpochTime]="currentEpochTime"
+            ></sofie-segment>
+        </ng-template>
     </ng-container>
 </div>
+

--- a/src/app/rundown-view/components/segment/segment.component.html
+++ b/src/app/rundown-view/components/segment/segment.component.html
@@ -6,7 +6,7 @@
   <div [cdkContextMenuTriggerFor]="contextMenu" class="header">
     <div class="header-toolbar">
       <span class="reference-tag">
-        {{segment.referenceTag}}
+        {{ segment.referenceTag }}
       </span>
       <span class="expected-duration">{{(!segment.isUntimed ? expectedDurationInMs : 0) | timer: 'HH?:mm:ss' }}</span>
       <span class="countdown">

--- a/src/app/rundown-view/components/segment/segment.component.html
+++ b/src/app/rundown-view/components/segment/segment.component.html
@@ -1,15 +1,15 @@
-<div class="c-segment"
-  [class.c-segment--on-air]="segment.isOnAir"
-  [class.c-segment--set-as-next]="segment.isNext"
-  [class.c-segment--has-remote-piece]="hasRemotePiece"
+<div class="segment ms-4 me-4 mt-1 mb-2"
+  [class.on-air]="segment.isOnAir"
+  [class.is-next]="segment.isNext"
+  [class.remote-piece]="hasRemotePiece"
 >
-  <div [cdkContextMenuTriggerFor]="contextMenu" class="c-segment__header">
-    <div class="c-segment__header-toolbar">
-      <span class="segment-reference-tag">
+  <div [cdkContextMenuTriggerFor]="contextMenu" class="header">
+    <div class="header-toolbar">
+      <span class="reference-tag">
         {{segment.referenceTag}}
       </span>
-      <span class="segment-expected-duration">{{(!segment.isUntimed ? expectedDurationInMs : 0) | timer: 'HH?:mm:ss' }}</span>
-      <span class="segment-countdown">
+      <span class="expected-duration">{{(!segment.isUntimed ? expectedDurationInMs : 0) | timer: 'HH?:mm:ss' }}</span>
+      <span class="countdown">
         <sofie-countdown-label
           *ngIf="hasRemotePiece && roundedDurationInMsUntilSegmentIsPutOnAir !== undefined"
           [durationInMs]="roundedDurationInMsUntilSegmentIsPutOnAir"
@@ -21,18 +21,18 @@
       <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
       <span class="ms-1">UNSYNCED</span>
     </div>
-    <div class="c-segment__title">
+    <div class="title">
       {{ segment.name }}
     </div>
   </div>
-  <div class="c-segment__controls">
-    <div class="c-segment__controls-toolbar">
+  <div class="controls">
+    <div class="controls-toolbar">
       <sofie-icon-button [icon]="Icon.MINUS" [iconSize]="IconSize.S" (click)="zoomIn()" [disabled]="isAtMinimumZoomLevel" title="Zoom out"></sofie-icon-button>
       <sofie-icon-button [icon]="Icon.HORIZONTAL_ARROWS" [iconSize]="IconSize.S" (click)="resetZoom()" title="Reset zoom"></sofie-icon-button>
       <sofie-icon-button [icon]="Icon.PLUS" [iconSize]="IconSize.S" (click)="zoomOut()" title="Zoom in"></sofie-icon-button>
     </div>
-    <div class="c-segment__piece-layers">
-      <div *ngFor="let outputLayer of outputLayers" class="c-segment__piece-layer">
+    <div class="piece-layers">
+      <div *ngFor="let outputLayer of outputLayers" class="piece-layer">
         {{ outputLayer }}
       </div>
     </div>
@@ -41,7 +41,7 @@
 
   <sofie-scrollable-timeline
     *ngIf="!segment.isOnAir; else onAirTimeline"
-    class="c-segment__timeline"
+    class="timeline"
     [segment]="segment"
     [outputLayers]="outputLayers"
     [isRundownActiveOrRehearsal]="isRundownActiveOrRehearsal"
@@ -51,7 +51,7 @@
 
   <ng-template #onAirTimeline>
     <sofie-follow-playhead-timeline
-      class="c-segment__timeline"
+      class="timeline"
       [time]="timeReference"
       [segment]="segment"
       [outputLayers]="outputLayers"

--- a/src/app/rundown-view/components/segment/segment.component.scss
+++ b/src/app/rundown-view/components/segment/segment.component.scss
@@ -1,12 +1,11 @@
-.c-segment {
+.segment {
   display: flex;
-  margin: 4px 20px;
   overflow: hidden;
   border-radius: 10px;
   box-shadow: 0 2px 2px 2px var(--gradient-black-rgba-with-02-opacity-color);
   --toolbar-height: 30px;
 
-  &__header {
+  .header {
     flex: 0;
     min-width: 270px;
     background-color: var(--rundown-segment-header-background-color);
@@ -14,35 +13,35 @@
     transition: background-color 0.2s;
   }
 
-  &--has-remote-piece &__header {
+  &.remote-piece .header {
     background-color: var(--tv2-remote-color);
   }
 
-  &--set-as-next &__header {
+  &.is-next .header {
     background-color: var(--next-color);
   }
 
-  &--on-air &__header {
+  &.on-air .header {
     background-color: var(--on-air-color);
   }
 
-  &__header-toolbar {
+  .header-toolbar {
     display: flex;
     justify-content: space-between;
     height: var(--toolbar-height);
     background: var(--black-color);
     padding: 6px;
 
-    .segment-reference-tag {
+    .reference-tag {
       flex: 1;
     }
 
-    .segment-expected-duration {
+    .expected-duration {
       flex: 1;
       text-align: center;
     }
 
-    .segment-countdown {
+    .countdown {
       flex: 1;
       text-align: right;
       font-weight: bolder;
@@ -67,7 +66,7 @@
     }
   }
 
-  &__title {
+  .title {
     padding: 7px;
     color: var(--text-color);
     font-size: 1.4em;
@@ -75,13 +74,13 @@
     word-break: break-word;
   }
 
-  &__controls {
+  .controls {
     flex: 0;
     min-width: 160px;
     background-color: var(--black-color);
   }
 
-  &__controls-toolbar {
+  .controls-toolbar {
     display: flex;
     flex-direction: row;
     justify-content: space-around;
@@ -114,14 +113,14 @@
     }
   }
 
-  &__piece-layer {
+  .piece-layer {
     color: var(--dark-gray-color);
     padding: 2px 0 2px 20px;
     font-weight: bold;
     height: 24px;
   }
 
-  &__timeline {
+  .timeline {
     overflow: hidden;
   }
 }

--- a/src/app/rundown-view/rundown-view.module.ts
+++ b/src/app/rundown-view/rundown-view.module.ts
@@ -36,6 +36,7 @@ import { PieceTooltipComponent } from './components/rundown-tooltips/piece-toolt
 import { MiniShelfCycleService } from './services/mini-shelf-cycle.service'
 import { MiniShelfNavigationService } from './services/mini-shelf-navigation.service'
 import { Tv2PieceTooltipContentFieldService } from './services/tv2-piece-tooltip-content-field.service'
+import { InvalidSegmentComponent } from './components/invalid-segment/invalid-segment.component'
 
 @NgModule({
   declarations: [
@@ -60,6 +61,7 @@ import { Tv2PieceTooltipContentFieldService } from './services/tv2-piece-tooltip
     CountdownLabelComponent,
     MiniShelfComponent,
     PieceTooltipComponent,
+    InvalidSegmentComponent,
   ],
   exports: [SegmentComponent],
   providers: [

--- a/src/app/shared/components/icon-button/icon-button.component.html
+++ b/src/app/shared/components/icon-button/icon-button.component.html
@@ -1,4 +1,4 @@
-<fa-icon sofieTooltip [sofieTooltipTemplate]="tooltipRef" [icon]="iconProp" [size]="iconSizeProp"></fa-icon>
+<fa-icon sofieTooltip [sofieTooltipTemplate]="tooltipRef" [icon]="iconProp" [size]="iconSizeProp" [ngClass]="{ disabled }"></fa-icon>
 
 <ng-template #tooltipRef>
   <sofie-text-tooltip i18n-text [text]="tooltip"></sofie-text-tooltip>

--- a/src/app/shared/components/icon-button/icon-button.component.scss
+++ b/src/app/shared/components/icon-button/icon-button.component.scss
@@ -5,4 +5,8 @@
   &:hover {
     color: var(--black-color);
   }
+
+  .disabled {
+    cursor: default;
+  }
 }

--- a/src/app/shared/services/rundown-navigation.service.ts
+++ b/src/app/shared/services/rundown-navigation.service.ts
@@ -35,7 +35,7 @@ export class RundownNavigationService {
   }
 
   private isValidSegment(segment: Segment): boolean {
-    return segment.parts.some(part => this.isValidPart(part))
+    return !segment.invalidity && segment.parts.some(part => this.isValidPart(part))
   }
 
   private isValidPart(part: Part): boolean {


### PR DESCRIPTION
Note: This PR is dependent on https://github.com/tv2/sofie-blueprints-inews/pull/243 and https://github.com/tv2/sofie-server/pull/152
Update: All dependent PRs have been merged.

Introduce `invalidity` on Segments. Segments that are invalid are not able to be taken. They are also shown differently to indicate that they are invalid.

Also in this PR:
Renamed the CSS classes in `segment.component.scss` to not follow the BEMIT convention.