### PR TITLE
Sof 1982/set color in keyboard mapping configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@tv2media/logger": "^2.0.2",
+    "ngx-colors": "3.1.4",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "uuid": "^9.0.1",

--- a/src/app/settings/keyboard-mapping-settings/components/edit-keyboard-mapping/edit-keyboard-mapping.component.html
+++ b/src/app/settings/keyboard-mapping-settings/components/edit-keyboard-mapping/edit-keyboard-mapping.component.html
@@ -6,6 +6,7 @@
       </sofie-keyboard-input>
       <sofie-keyboard-input i18n-label label="action-triggers.physical-mapping.label" [formControlName]="'mappedToKeys'" i18n-helpText helpText="action-triggers.physical-mapping-help.tooltip">
       </sofie-keyboard-input>
+      <sofie-color-picker i18n-label label="action-triggers.override-color.label" i18n-placeholder placeholder="color-picker.choose-color.placeholder" i18n-helpText helpText="action-triggers.override-color.help-text" [formControlName]="'overrideColor'"></sofie-color-picker>
       <sofie-select
         i18n-label
         label="action-triggers.trigger-on.label"

--- a/src/app/settings/keyboard-mapping-settings/components/edit-keyboard-mapping/edit-keyboard-mapping.component.ts
+++ b/src/app/settings/keyboard-mapping-settings/components/edit-keyboard-mapping/edit-keyboard-mapping.component.ts
@@ -43,6 +43,7 @@ export class EditKeyboardMappingComponent implements OnInit {
     this.actionTriggerDataForm = this.formBuilder.group({
       label: [this.keyboardMapping?.actionTrigger.data.label ?? ''],
       keys: [this.keyboardMapping?.actionTrigger.data.keys, [Validators.required]],
+      overrideColor: [this.keyboardMapping?.actionTrigger.data.overrideColor ?? ''],
       triggerOn: [KeyEventType.RELEASED, [Validators.required]],
       mappedToKeys: [this.keyboardMapping?.actionTrigger.data.mappedToKeys ?? []],
     })

--- a/src/app/settings/keyboard-mapping-settings/components/edit-keyboard-mapping/edit-keyboard-mapping.component.ts
+++ b/src/app/settings/keyboard-mapping-settings/components/edit-keyboard-mapping/edit-keyboard-mapping.component.ts
@@ -43,7 +43,7 @@ export class EditKeyboardMappingComponent implements OnInit {
     this.actionTriggerDataForm = this.formBuilder.group({
       label: [this.keyboardMapping?.actionTrigger.data.label ?? ''],
       keys: [this.keyboardMapping?.actionTrigger.data.keys, [Validators.required]],
-      overrideColor: [this.keyboardMapping?.actionTrigger.data.overrideColor ?? ''],
+      overrideColor: [this.keyboardMapping?.actionTrigger.data.overrideColor],
       triggerOn: [KeyEventType.RELEASED, [Validators.required]],
       mappedToKeys: [this.keyboardMapping?.actionTrigger.data.mappedToKeys ?? []],
     })

--- a/src/app/shared/components/color-picker/color-picker.component.html
+++ b/src/app/shared/components/color-picker/color-picker.component.html
@@ -4,9 +4,10 @@
     <sofie-icon-button *ngIf="helpText" [tooltip]="helpText" [icon]="Icon.CIRCLE_QUESTION" [iconSize]="IconSize.M"></sofie-icon-button>
   </span>
     <div class="color-picker" ngx-colors-trigger [(ngModel)]="value" [palette]="palette" [colorPickerControls]="'no-alpha'" [format]="'hex'" (input)="emitChanges()" (click)="markAsTouched()">
-        <div class="color-box" [style]="{ 'background': getColor }">
+        <span *ngIf="!!value" class="color-box" [style]="{ 'background': getColor }"></span>
+        <span class="text">
             {{ !!value ? value : placeholder ?? label }}
-        </div>
+        </span>
         <sofie-icon-button *ngIf="value" [icon]="Icon.X_MARK" [iconSize]="IconSize.L" (click)="clearValue($event)"></sofie-icon-button>
     </div>
     <sofie-error-message *ngIf="errorMessage">{{ errorMessage }}</sofie-error-message>

--- a/src/app/shared/components/color-picker/color-picker.component.html
+++ b/src/app/shared/components/color-picker/color-picker.component.html
@@ -4,11 +4,11 @@
     <sofie-icon-button *ngIf="helpText" [tooltip]="helpText" [icon]="Icon.CIRCLE_QUESTION" [iconSize]="IconSize.M"></sofie-icon-button>
   </span>
     <div class="color-picker" ngx-colors-trigger [(ngModel)]="value" [palette]="palette" [colorPickerControls]="'no-alpha'" [format]="'hex'" (input)="emitChanges()" (click)="markAsTouched()">
-        <span *ngIf="!!value" class="color-box" [style]="{ 'background': getColor }"></span>
+        <span *ngIf="!!value" class="color-box" [style]="{ 'background': getColor() }"></span>
         <span class="text">
             {{ !!value ? value : placeholder ?? label }}
         </span>
-        <sofie-icon-button *ngIf="value" [icon]="Icon.X_MARK" [iconSize]="IconSize.L" (click)="clearValue($event)"></sofie-icon-button>
+        <sofie-icon-button *ngIf="value" [icon]="Icon.X_MARK" [iconSize]="IconSize.L" (click)="clearValue(); $event.stopPropagation()"></sofie-icon-button>
     </div>
     <sofie-error-message *ngIf="errorMessage">{{ errorMessage }}</sofie-error-message>
 </div>

--- a/src/app/shared/components/color-picker/color-picker.component.html
+++ b/src/app/shared/components/color-picker/color-picker.component.html
@@ -1,14 +1,14 @@
-<div class="container pt-2 pb-2">
-  <span *ngIf="label || helpText" class="mb-1">
+<div class="pt-2 pb-2">
+  <div *ngIf="label || helpText" class="label-container mb-1">
     <label *ngIf="label">{{ label }}<sofie-required-mark *ngIf="isRequired"></sofie-required-mark></label>
     <sofie-icon-button *ngIf="helpText" [tooltip]="helpText" [icon]="Icon.CIRCLE_QUESTION" [iconSize]="IconSize.M"></sofie-icon-button>
-  </span>
+  </div>
     <div class="color-picker" ngx-colors-trigger [(ngModel)]="value" [palette]="palette" [colorPickerControls]="'no-alpha'" [format]="'hex'" (input)="emitChanges()" (click)="markAsTouched()">
-        <span *ngIf="!!value" class="color-box" [style]="{ 'background': getColor() }"></span>
-        <span class="text">
-            {{ !!value ? value : placeholder ?? label }}
+        <span *ngIf="value" class="color-box" [style.background]="getColor()"></span>
+        <span class="input-text">
+            {{ value || placeholder ?? label }}
         </span>
         <sofie-icon-button *ngIf="value" [icon]="Icon.X_MARK" [iconSize]="IconSize.L" (click)="clearValue(); $event.stopPropagation()"></sofie-icon-button>
     </div>
-    <sofie-error-message *ngIf="errorMessage">{{ errorMessage }}</sofie-error-message>
+<sofie-error-message *ngIf="errorMessage">{{ errorMessage }}</sofie-error-message>
 </div>

--- a/src/app/shared/components/color-picker/color-picker.component.html
+++ b/src/app/shared/components/color-picker/color-picker.component.html
@@ -1,0 +1,13 @@
+<div class="container pt-2 pb-2">
+  <span *ngIf="label || helpText" class="mb-1">
+    <label *ngIf="label">{{ label }}<sofie-required-mark *ngIf="isRequired"></sofie-required-mark></label>
+    <sofie-icon-button *ngIf="helpText" [tooltip]="helpText" [icon]="Icon.CIRCLE_QUESTION" [iconSize]="IconSize.M"></sofie-icon-button>
+  </span>
+    <div class="color-picker" ngx-colors-trigger [(ngModel)]="value" [palette]="palette" [colorPickerControls]="'no-alpha'" [format]="'hex'" (input)="emitChanges()" (click)="markAsTouched()">
+        <div class="color-box" [style]="{ 'background': getColor }">
+            {{ !!value ? value : placeholder ?? label }}
+        </div>
+        <sofie-icon-button *ngIf="value" [icon]="Icon.X_MARK" [iconSize]="IconSize.L" (click)="clearValue($event)"></sofie-icon-button>
+    </div>
+    <sofie-error-message *ngIf="errorMessage">{{ errorMessage }}</sofie-error-message>
+</div>

--- a/src/app/shared/components/color-picker/color-picker.component.scss
+++ b/src/app/shared/components/color-picker/color-picker.component.scss
@@ -17,6 +17,8 @@
 
 .color-picker {
   position: relative;
+  display: flex;
+  flex-direction: row;
   width: 100%;
   padding: 0.3rem 0.3rem;
   font-weight: lighter;
@@ -35,6 +37,13 @@
 
 .color-box {
   padding: 0.2rem 0.5rem;
+  width: 50px;
+  height: 22px;
+  border-radius: 4px;
+}
+
+.text {
+  padding: 0.2rem;
   font-weight: lighter;
   font-size: 0.85rem;
   font-family: Roboto, Arial, sans-serif;

--- a/src/app/shared/components/color-picker/color-picker.component.scss
+++ b/src/app/shared/components/color-picker/color-picker.component.scss
@@ -1,0 +1,55 @@
+:host {
+  &.ng-invalid {
+    &.ng-touched {
+      input {
+        border-color: var(--danger-color);
+      }
+    }
+  }
+
+  &.ng-valid,
+  &.ng-untouched {
+    sofie-error-message {
+      display: none;
+    }
+  }
+}
+
+.color-picker {
+  position: relative;
+  width: 100%;
+  padding: 0.3rem 0.3rem;
+  font-weight: lighter;
+  font-size: 0.85rem;
+  font-family: Roboto, Arial, sans-serif;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid var(--gray-color);
+
+  sofie-icon-button {
+    position: absolute;
+    right: 10px;
+    top: 8px;
+  }
+}
+
+.color-box {
+  padding: 0.2rem 0.5rem;
+  font-weight: lighter;
+  font-size: 0.85rem;
+  font-family: Roboto, Arial, sans-serif;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+span {
+  display: flex;
+  justify-content: space-between;
+}
+
+label {
+  font-weight: lighter;
+}

--- a/src/app/shared/components/color-picker/color-picker.component.scss
+++ b/src/app/shared/components/color-picker/color-picker.component.scss
@@ -19,14 +19,13 @@
   position: relative;
   display: flex;
   flex-direction: row;
-  width: 100%;
   padding: 0.3rem 0.3rem;
   font-weight: lighter;
   font-size: 0.85rem;
   font-family: Roboto, Arial, sans-serif;
   border-radius: 4px;
-  cursor: pointer;
   border: 1px solid var(--gray-color);
+  cursor: pointer;
 
   sofie-icon-button {
     position: absolute;
@@ -36,25 +35,18 @@
 }
 
 .color-box {
-  padding: 0.2rem 0.5rem;
-  width: 50px;
-  height: 22px;
+  height: 1.5rem;
+  aspect-ratio: 16 / 9;
   border-radius: 4px;
 }
 
-.text {
+.input-text {
   padding: 0.2rem;
   font-weight: lighter;
   font-size: 0.85rem;
-  font-family: Roboto, Arial, sans-serif;
 }
 
-.container {
-  display: flex;
-  flex-direction: column;
-}
-
-span {
+.label-container {
   display: flex;
   justify-content: space-between;
 }

--- a/src/app/shared/components/color-picker/color-picker.component.spec.ts
+++ b/src/app/shared/components/color-picker/color-picker.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { ColorPickerComponent } from './color-picker.component'
+
+describe('ColorPickerComponent', () => {
+  let component: ColorPickerComponent
+  let fixture: ComponentFixture<ColorPickerComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ColorPickerComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(ColorPickerComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/shared/components/color-picker/color-picker.component.ts
+++ b/src/app/shared/components/color-picker/color-picker.component.ts
@@ -3,6 +3,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms'
 import { Icon, IconSize } from '../../enums/icon'
 
 const DEFAULT_COLOR: string = '#FFFFFF00'
+const NO_COLOR: string = ''
 
 @Component({
   selector: 'sofie-color-picker',
@@ -47,7 +48,7 @@ export class ColorPickerComponent implements ControlValueAccessor {
 
   @Output() public valueChange: EventEmitter<string> = new EventEmitter()
 
-  protected value?: string
+  protected value: string
 
   private isTouched: boolean = false
 
@@ -56,7 +57,7 @@ export class ColorPickerComponent implements ControlValueAccessor {
 
   constructor() {}
 
-  protected get getColor(): string {
+  protected getColor(): string {
     return this.value ?? DEFAULT_COLOR
   }
 
@@ -73,9 +74,8 @@ export class ColorPickerComponent implements ControlValueAccessor {
     this.isTouched = true
   }
 
-  protected clearValue(event: Event): void {
-    event.stopPropagation()
-    this.value = undefined
+  protected clearValue(): void {
+    this.value = NO_COLOR
     this.onChangeCallback?.(this.value)
   }
 

--- a/src/app/shared/components/color-picker/color-picker.component.ts
+++ b/src/app/shared/components/color-picker/color-picker.component.ts
@@ -1,0 +1,93 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms'
+import { Icon, IconSize } from '../../enums/icon'
+
+const DEFAULT_COLOR: string = '#FFFFFF00'
+
+@Component({
+  selector: 'sofie-color-picker',
+  templateUrl: './color-picker.component.html',
+  styleUrls: ['./color-picker.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      multi: true,
+      useExisting: ColorPickerComponent,
+    },
+  ],
+})
+export class ColorPickerComponent implements ControlValueAccessor {
+  protected readonly Icon = Icon
+  protected readonly IconSize = IconSize
+
+  protected readonly palette: string[] = [
+    '#343434',
+    '#005919',
+    '#8d1010',
+    '#c40000',
+    '#ac29a5',
+    '#b99000',
+    '#00a99c',
+    '#265753',
+    '#370020',
+    '#1769ff',
+    '#370020',
+    '#016492',
+    '#003c58',
+    '#00ac17',
+    '#ef6c00',
+  ]
+
+  @Input() public label: string
+  @Input() public placeholder?: string
+
+  @Input() public helpText: string
+  @Input() public isRequired: boolean
+  @Input() public errorMessage?: string
+
+  @Output() public valueChange: EventEmitter<string> = new EventEmitter()
+
+  protected value?: string
+
+  private isTouched: boolean = false
+
+  private onChangeCallback: (value?: string) => void
+  private onTouchedCallback: () => void
+
+  constructor() {}
+
+  protected get getColor(): string {
+    return this.value ?? DEFAULT_COLOR
+  }
+
+  protected emitChanges(): void {
+    this.valueChange.emit(this.value)
+    this.onChangeCallback?.(this.value)
+  }
+
+  protected markAsTouched(): void {
+    if (!this.onTouchedCallback || this.isTouched) {
+      return
+    }
+    this.onTouchedCallback()
+    this.isTouched = true
+  }
+
+  protected clearValue(event: Event): void {
+    event.stopPropagation()
+    this.value = undefined
+    this.onChangeCallback?.(this.value)
+  }
+
+  public registerOnChange(onChange: (value?: string) => void): void {
+    this.onChangeCallback = onChange
+  }
+
+  public registerOnTouched(onTouched: () => void): void {
+    this.onTouchedCallback = onTouched
+  }
+
+  public writeValue(value: string): void {
+    this.value = value
+  }
+}

--- a/src/app/shared/components/keyboard-input/keyboard-input.component.html
+++ b/src/app/shared/components/keyboard-input/keyboard-input.component.html
@@ -1,5 +1,5 @@
 <div class="pt-2 pb-2">
-  <sofie-row class="mb-1">
+  <sofie-row class="label-container mb-1">
     <label *ngIf="label">{{ label }}<sofie-required-mark *ngIf="isRequired"></sofie-required-mark></label>
     <sofie-icon-button *ngIf="helpText" [tooltip]="helpText" [icon]="Icon.CIRCLE_QUESTION" [iconSize]="IconSize.M"></sofie-icon-button>
   </sofie-row>

--- a/src/app/shared/components/multi-select/multi-select.component.html
+++ b/src/app/shared/components/multi-select/multi-select.component.html
@@ -8,7 +8,7 @@
             <sofie-icon-button *ngIf="selectedOptions.length > 0" [icon]="Icon.X_MARK" (click)="clearAllSelected(); $event.stopPropagation()" class="ms-1"></sofie-icon-button>
         </div>
 
-        <div *ngIf="isShowingOptions" class="multi-select-dropdown" >
+        <div *ngIf="isOpen" class="multi-select-dropdown" >
             <div *ngFor="let option of selectableOptions" class="multi-select-dropdown-item p-3" (click)="toggleOption(option)">
                 {{ option.name }}
                 <sofie-icon-button *ngIf="option.isSelected" [icon]="Icon.CHECK" [iconSize]="IconSize.M"></sofie-icon-button>

--- a/src/app/shared/components/multi-select/multi-select.component.ts
+++ b/src/app/shared/components/multi-select/multi-select.component.ts
@@ -22,7 +22,7 @@ interface SelectableOption<T> extends SelectOption<T> {
 export class MultiSelectComponent<T> implements OnInit, ControlValueAccessor {
   protected Icon = Icon
   protected IconSize = IconSize
-  protected isShowingOptions: boolean = false
+  protected isOpen: boolean = false
   protected hasBeenClicked: boolean = true
 
   @Input() public options: SelectOption<T>[] = []
@@ -125,14 +125,14 @@ export class MultiSelectComponent<T> implements OnInit, ControlValueAccessor {
   }
 
   protected toggleIsShowingOptions(): void {
-    this.isShowingOptions = !this.isShowingOptions
-    if (this.isShowingOptions) {
+    this.isOpen = !this.isOpen
+    if (this.isOpen) {
       this.addClickListenerForDropdownClose()
     }
   }
 
   private addClickListenerForDropdownClose(): void {
-    document.addEventListener('click', () => (this.hasBeenClicked ? (this.isShowingOptions = false) : this.addClickListenerForDropdownClose()), { once: true })
+    document.addEventListener('click', () => (this.hasBeenClicked ? (this.isOpen = false) : this.addClickListenerForDropdownClose()), { once: true })
   }
 
   public registerOnChange(changeCallback: (value: T[]) => void): void {

--- a/src/app/shared/components/notification-card/notification-card.component.scss
+++ b/src/app/shared/components/notification-card/notification-card.component.scss
@@ -22,7 +22,7 @@
   }
 }
 
-.text {
+.input-text {
   overflow-wrap: break-word;
 }
 

--- a/src/app/shared/models/keyboard-trigger-data.ts
+++ b/src/app/shared/models/keyboard-trigger-data.ts
@@ -5,6 +5,7 @@ export interface KeyboardTriggerData {
   keys: Keys
   actionArguments?: string | number
   label: string
+  overrideColor?: string
   triggerOn: KeyEventType
   mappedToKeys?: Keys
 }

--- a/src/app/shared/models/keyboard-trigger-data.ts
+++ b/src/app/shared/models/keyboard-trigger-data.ts
@@ -5,7 +5,7 @@ export interface KeyboardTriggerData {
   keys: Keys
   actionArguments?: string | number
   label: string
-  overrideColor?: string
+  overrideColor: string
   triggerOn: KeyEventType
   mappedToKeys?: Keys
 }

--- a/src/app/shared/services/zod-action-trigger-parser.service.ts
+++ b/src/app/shared/services/zod-action-trigger-parser.service.ts
@@ -16,7 +16,7 @@ export class ZodActionTriggerParser extends ActionTriggerParser {
     mappedToKeys: zod.string().array().optional() as unknown as zod.ZodType<Keys>,
     triggerOn: zod.nativeEnum(KeyEventType),
     label: zod.string(),
-    overrideColor: zod.string().optional(),
+    overrideColor: zod.string().default(''),
     actionArguments: zod.number().or(zod.string().optional()).optional(),
   })
 

--- a/src/app/shared/services/zod-action-trigger-parser.service.ts
+++ b/src/app/shared/services/zod-action-trigger-parser.service.ts
@@ -16,6 +16,7 @@ export class ZodActionTriggerParser extends ActionTriggerParser {
     mappedToKeys: zod.string().array().optional() as unknown as zod.ZodType<Keys>,
     triggerOn: zod.nativeEnum(KeyEventType),
     label: zod.string(),
+    overrideColor: zod.string().optional(),
     actionArguments: zod.number().or(zod.string().optional()).optional(),
   })
 

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -90,6 +90,8 @@ import { RequiredMarkComponent } from './components/required-mark/required-mark.
 import { DialogConfirmationService } from './services/dialog-confirmation.service'
 import { ActionSelectorComponent } from './components/action-selector/action-selector.component'
 import { VideoHoverScrubComponent } from './components/video-hover-scrub/video-hover-scrub.component'
+import { ColorPickerComponent } from './components/color-picker/color-picker.component'
+import { NgxColorsModule } from 'ngx-colors'
 
 @NgModule({
   declarations: [
@@ -138,6 +140,7 @@ import { VideoHoverScrubComponent } from './components/video-hover-scrub/video-h
     ErrorMessageComponent,
     RequiredMarkComponent,
     VideoHoverScrubComponent,
+    ColorPickerComponent,
   ],
   imports: [
     CommonModule,
@@ -158,6 +161,7 @@ import { VideoHoverScrubComponent } from './components/video-hover-scrub/video-h
     MatProgressSpinnerModule,
     MatMenuModule,
     RouterModule,
+    NgxColorsModule,
   ],
   exports: [
     CommonModule,
@@ -204,6 +208,7 @@ import { VideoHoverScrubComponent } from './components/video-hover-scrub/video-h
     ErrorMessageComponent,
     RequiredMarkComponent,
     VideoHoverScrubComponent,
+    ColorPickerComponent,
   ],
   providers: [
     { provide: Logger, useClass: Tv2LoggerService },

--- a/src/app/test/factories/test-entity.factory.ts
+++ b/src/app/test/factories/test-entity.factory.ts
@@ -87,6 +87,7 @@ export class TestEntityFactory {
         actionArguments: 100,
         label: 'random-label',
         triggerOn: KeyEventType.RELEASED,
+        overrideColor: '',
       },
       ...actionTrigger,
     }

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -500,7 +500,7 @@
       </trans-unit>
       <trans-unit id="4439615397476866844" datatype="html">
         <source>action-triggers.override-color.help-text</source>
-        <target state="new">Vælg en ny farve hvis du gerne overskrive standard farven for genvejen.</target>
+        <target state="new">Vælg en ny farve hvis du gerne vil overskrive standard farven for genvejen.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -492,7 +492,7 @@
       </trans-unit>
       <trans-unit id="8483503986037571867" datatype="html">
         <source>action-triggers.override-color.label</source>
-        <target state="new">Overskriv standard farve</target>
+        <target state="new">Overskriv genvejs farven</target>
       </trans-unit>
       <trans-unit id="2313705565869821168" datatype="html">
         <source>color-picker.choose-color.placeholder</source>
@@ -500,7 +500,7 @@
       </trans-unit>
       <trans-unit id="4439615397476866844" datatype="html">
         <source>action-triggers.override-color.help-text</source>
-        <target state="new">Vælg en ny farve hvis du gerne vil overskrive standard farven for genvejen.</target>
+        <target state="new">Vælg en ny farve hvis du gerne vil overskrive farven for genvejen.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -452,8 +452,7 @@
       </trans-unit>
       <trans-unit id="3626510894964414637" datatype="html">
         <source>dialog.message.activation.warning</source>
-        <target state="new">Er du sikker på du vil aktivere denne Rundown?
-        Det vil deaktivere Rundown</target>
+        <target state="new">Er du sikker på du vil aktivere denne Rundown? Det vil deaktivere Rundown</target>
       </trans-unit>
       <trans-unit id="6370990329720066506" datatype="html">
         <source>dialog.message.rehearse</source>
@@ -461,8 +460,7 @@
       </trans-unit>
       <trans-unit id="2994423491366084246" datatype="html">
         <source>dialog.message.rehearse.warning</source>
-        <target state="new">Er du sikker på at du vil afprøve denne Rundown?
-        Det vil deaktivere Rundown</target>
+        <target state="new">Er du sikker på at du vil afprøve denne Rundown? Det vil deaktivere Rundown</target>
       </trans-unit>
       <trans-unit id="3407985762844707521" datatype="html">
         <source>static-buttons-configuration.card-header</source>
@@ -488,13 +486,21 @@
         <source>keyboard-mapping-settings-page.delete-all-keyboard-mappings.success <x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/></source>
         <target state="new"><x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/> genveje blev slettet</target>
       </trans-unit>
-      <trans-unit id="6774239910313063167" datatype="html">
-        <source>keyboard-mapping.settings-page.invalid-field</source>
-        <target state="new">Ugyldig data, skal redigeres. </target>
-      </trans-unit>
       <trans-unit id="5805882241277564116" datatype="html">
         <source>keyboard-mapping-settings-page-import-keyboard-mappings.actions-missing</source>
         <target state="new">En eller flere importeret genveje havde en ugyldig action og blev derfor ikke importeret!</target>
+      </trans-unit>
+      <trans-unit id="8483503986037571867" datatype="html">
+        <source>action-triggers.override-color.label</source>
+        <target state="new">Overskriv standard farve</target>
+      </trans-unit>
+      <trans-unit id="2313705565869821168" datatype="html">
+        <source>color-picker.choose-color.placeholder</source>
+        <target state="new">Vælg en farve</target>
+      </trans-unit>
+      <trans-unit id="4439615397476866844" datatype="html">
+        <source>action-triggers.override-color.help-text</source>
+        <target state="new">Vælg en ny farve hvis du gerne overskrive standard farven for genvejen.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.en-US.xlf
+++ b/src/locale/messages.en-US.xlf
@@ -486,13 +486,21 @@
         <source>keyboard-mapping-settings-page.delete-all-keyboard-mappings.success <x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/></source>
         <target state="new">The <x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/> selected keyboard mappings have been deleted.</target>
       </trans-unit>
-      <trans-unit id="6774239910313063167" datatype="html">
-        <source>keyboard-mapping.settings-page.invalid-field</source>
-        <target state="new">Invalid data, needs to be edited.</target>
-      </trans-unit>
       <trans-unit id="5805882241277564116" datatype="html">
         <source>keyboard-mapping-settings-page-import-keyboard-mappings.actions-missing</source>
         <target state="new">One or more keyboard mappings contained invalid actions and were not imported!</target>
+      </trans-unit>
+      <trans-unit id="8483503986037571867" datatype="html">
+        <source>action-triggers.override-color.label</source>
+        <target state="new">Override default color</target>
+      </trans-unit>
+      <trans-unit id="2313705565869821168" datatype="html">
+        <source>color-picker.choose-color.placeholder</source>
+        <target state="new">Choose a color</target>
+      </trans-unit>
+      <trans-unit id="4439615397476866844" datatype="html">
+        <source>action-triggers.override-color.help-text</source>
+        <target state="new">Choose a color if you want to override the default color of the keyboard mapping.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.en-US.xlf
+++ b/src/locale/messages.en-US.xlf
@@ -500,7 +500,7 @@
       </trans-unit>
       <trans-unit id="4439615397476866844" datatype="html">
         <source>action-triggers.override-color.help-text</source>
-        <target state="new">Choose a color if you want to override the default color of the keyboard mapping.</target>
+        <target state="new">Choose a color if you want to override the key color of the keyboard mapping.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.en-US.xlf
+++ b/src/locale/messages.en-US.xlf
@@ -492,7 +492,7 @@
       </trans-unit>
       <trans-unit id="8483503986037571867" datatype="html">
         <source>action-triggers.override-color.label</source>
-        <target state="new">Override default color</target>
+        <target state="new">Override key color</target>
       </trans-unit>
       <trans-unit id="2313705565869821168" datatype="html">
         <source>color-picker.choose-color.placeholder</source>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -365,11 +365,17 @@
       <trans-unit id="3477258835430959446" datatype="html">
         <source>keyboard-mapping-settings-page.delete-all-keyboard-mappings.success <x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/></source>
       </trans-unit>
-      <trans-unit id="6774239910313063167" datatype="html">
-        <source>keyboard-mapping.settings-page.invalid-field</source>
-      </trans-unit>
       <trans-unit id="5805882241277564116" datatype="html">
         <source>keyboard-mapping-settings-page-import-keyboard-mappings.actions-missing</source>
+      </trans-unit>
+      <trans-unit id="2313705565869821168" datatype="html">
+        <source>color-picker.choose-color.placeholder</source>
+      </trans-unit>
+      <trans-unit id="4439615397476866844" datatype="html">
+        <source>action-triggers.override-color.help-text</source>
+      </trans-unit>
+      <trans-unit id="8483503986037571867" datatype="html">
+        <source>action-triggers.override-color.label</source>
       </trans-unit>
     </body>
   </file>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7776,6 +7776,7 @@ __metadata:
     karma-jasmine: ~5.1.0
     karma-jasmine-html-reporter: ~2.0.0
     ng-extract-i18n-merge: 2.8.3
+    ngx-colors: 3.1.4
     prettier: ^3.0.3
     prettier-eslint: ^15.0.1
     rimraf: ^5.0.5
@@ -7787,6 +7788,20 @@ __metadata:
     zone.js: ~0.11.4
   languageName: unknown
   linkType: soft
+
+"ngx-colors@npm:3.1.4":
+  version: 3.1.4
+  resolution: "ngx-colors@npm:3.1.4"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    "@angular/animations": ">=13.1.1"
+    "@angular/common": ">=13.1.1"
+    "@angular/core": ">=13.1.1"
+    "@angular/forms": ">=13.1.1"
+  checksum: d9e92d838c10fc10b7732e00ba6a40ae704f66d78a4852bfd0b35707fbb016bf0329c7e2fa2ce0e7197cf239d397a163102c309be8262c08357b08452fae2c6d
+  languageName: node
+  linkType: hard
 
 "nice-napi@npm:^1.0.2":
   version: 1.0.2
@@ -10476,7 +10491,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.0":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
Note: Is dependent on https://github.com/tv2/ng-sofie/pull/203
All dependent PRs have been merged.

Introduce ColorPickerComponent.

Now possible to select an "override color" when creating an KeyboardMapping. For now, the selected color does nothing (it will be implemented by SOF-1983).