### PR TITLE
On air segments have sticks to viewport boundaries.

### DIFF
--- a/src/app/rundown-view/components/rundown/rundown.component.html
+++ b/src/app/rundown-view/components/rundown/rundown.component.html
@@ -4,14 +4,14 @@
         </sofie-invalid-segment>
         <ng-template #miniShelfTemplate>
             <sofie-mini-shelf
-                    *ngIf="segment.metadata?.miniShelfVideoClipFile; else segmentTemplate"
+                    *ngIf="segment.metadata?.miniShelfVideoClipFile; else onAirSegmentTemplate"
                     [segment]="segment"
                     [videoClipAction]="miniShelfSegmentActionMappings[segment.id]"
             ></sofie-mini-shelf>
         </ng-template>
-        <ng-template #segmentTemplate>
-            <sofie-segment
-                    *ngIf="!segment.isHidden"
+        <ng-template #onAirSegmentTemplate>
+            <sofie-sticky-segment
+                    *ngIf="segment.isOnAir; else segmentTemplate"
                     [attr.data-segment-id]="segment.id"
                     [segment]="segment"
                     [isRundownActiveOrRehearsal]="isActiveOrRehearsal"
@@ -19,7 +19,19 @@
                     [durationInMsUntilSegmentIsPutOnAir]="startOffsetsInMsFromPlayheadForSegments[segment.id]"
                     [remainingDurationInMsForOnAirPart]="remainingDurationInMsForOnAirPart"
                     [currentEpochTime]="currentEpochTime"
-            ></sofie-segment>
+            ></sofie-sticky-segment>
+        </ng-template>
+        <ng-template #segmentTemplate>
+          <sofie-segment
+            *ngIf="!segment.isHidden"
+            [attr.data-segment-id]="segment.id"
+            [segment]="segment"
+            [isRundownActiveOrRehearsal]="isActiveOrRehearsal"
+            [isAutoNextStarted]="isAutoNextStarted"
+            [durationInMsUntilSegmentIsPutOnAir]="startOffsetsInMsFromPlayheadForSegments[segment.id]"
+            [remainingDurationInMsForOnAirPart]="remainingDurationInMsForOnAirPart"
+            [currentEpochTime]="currentEpochTime"
+          ></sofie-segment>
         </ng-template>
     </ng-container>
 </div>

--- a/src/app/rundown-view/components/rundown/rundown.component.scss
+++ b/src/app/rundown-view/components/rundown/rundown.component.scss
@@ -1,18 +1,15 @@
 :host {
   display: flex;
   flex-direction: column;
-  background-color: var(--background-color);
   height: 100%;
+  background-color: var(--background-color);
+  scroll-padding: 200px 0;
   overflow: auto;
 
   .segments {
     margin: 20px 0 300px 0;
     display: flex;
     flex-direction: column;
-  }
-
-  sofie-segment {
-    scroll-margin: 100px;
   }
 }
 

--- a/src/app/rundown-view/components/segment/segment.component.html
+++ b/src/app/rundown-view/components/segment/segment.component.html
@@ -27,7 +27,7 @@
   </div>
   <div class="controls">
     <div class="controls-toolbar">
-      <sofie-icon-button [icon]="Icon.MINUS" [iconSize]="IconSize.S" (click)="zoomIn()" [disabled]="isAtMinimumZoomLevel" title="Zoom out"></sofie-icon-button>
+      <sofie-icon-button [icon]="Icon.MINUS" [iconSize]="IconSize.S" (click)="zoomIn()" [disabled]="isAtMinimumZoomLevel()" title="Zoom out"></sofie-icon-button>
       <sofie-icon-button [icon]="Icon.HORIZONTAL_ARROWS" [iconSize]="IconSize.S" (click)="resetZoom()" title="Reset zoom"></sofie-icon-button>
       <sofie-icon-button [icon]="Icon.PLUS" [iconSize]="IconSize.S" (click)="zoomOut()" title="Zoom in"></sofie-icon-button>
     </div>

--- a/src/app/rundown-view/components/segment/segment.component.ts
+++ b/src/app/rundown-view/components/segment/segment.component.ts
@@ -49,7 +49,7 @@ export class SegmentComponent implements OnChanges, OnDestroy {
   public roundedDurationInMsUntilSegmentIsPutOnAir?: number
 
   public pixelsPerSecond: number = INITIAL_PIXELS_PER_SECOND
-  public get isAtMinimumZoomLevel(): boolean {
+  public isAtMinimumZoomLevel(): boolean {
     return this.pixelsPerSecond <= MINIMUM_PIXELS_PER_SECOND
   }
 

--- a/src/app/rundown-view/components/sticky-segment/sticky-segment.component.html
+++ b/src/app/rundown-view/components/sticky-segment/sticky-segment.component.html
@@ -1,0 +1,8 @@
+<sofie-segment
+  [segment]="segment"
+  [isRundownActiveOrRehearsal]="isRundownActiveOrRehearsal"
+  [isAutoNextStarted]="isAutoNextStarted"
+  [durationInMsUntilSegmentIsPutOnAir]="durationInMsUntilSegmentIsPutOnAir"
+  [remainingDurationInMsForOnAirPart]="remainingDurationInMsForOnAirPart"
+  [currentEpochTime]="currentEpochTime"
+></sofie-segment>

--- a/src/app/rundown-view/components/sticky-segment/sticky-segment.component.scss
+++ b/src/app/rundown-view/components/sticky-segment/sticky-segment.component.scss
@@ -1,0 +1,14 @@
+:host {
+  display: block;
+  position: sticky;
+  top: -1px;
+  bottom: -1px;
+  z-index: 250;
+  transition: padding .2s, background-color .2s, box-shadow .2s;
+
+  &.stuck {
+    padding: 10px 0;
+    background-color: var(--dark-gray-color);
+    box-shadow: 0 0 10px 0 #000000;
+  }
+}

--- a/src/app/rundown-view/components/sticky-segment/sticky-segment.component.scss
+++ b/src/app/rundown-view/components/sticky-segment/sticky-segment.component.scss
@@ -9,6 +9,6 @@
   &.stuck {
     padding: 10px 0;
     background-color: var(--dark-gray-color);
-    box-shadow: 0 0 10px 0 #000000;
+    box-shadow: 0 0 10px 0 var(--black-color);
   }
 }

--- a/src/app/rundown-view/components/sticky-segment/sticky-segment.component.spec.ts
+++ b/src/app/rundown-view/components/sticky-segment/sticky-segment.component.spec.ts
@@ -1,60 +1,22 @@
-import { TestBed } from '@angular/core/testing'
-import { Segment } from 'src/app/core/models/segment'
-
-import { SegmentComponent } from './sticky-segment.component'
-import { instance, mock, when } from '@typestrong/ts-mockito'
-import { Tv2OutputLayerService } from '../../../shared/services/tv2-output-layer.service'
-import { SegmentEntityService } from '../../../core/services/models/segment-entity.service'
-import { PartEntityService } from '../../../core/services/models/part-entity.service'
-import { RundownService } from '../../../core/abstractions/rundown.service'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { SharedModule } from '../../../shared/shared.module'
-import { Logger } from '../../../core/abstractions/logger.service'
-import { TestLoggerFactory } from '../../../test/factories/test-logger.factory'
-import { IconService } from 'src/app/core/abstractions/icon.service'
+import { StickySegmentComponent } from './sticky-segment.component'
+import { TestEntityFactory } from '../../../test/factories/test-entity.factory'
 
 describe('SegmentComponent', () => {
   it('should create', async () => {
     await configureTestBed()
-    const fixture = TestBed.createComponent(SegmentComponent)
-    const component = fixture.componentInstance
-    const mockedSegment = getMockedSegment()
-    component.segment = instance(mockedSegment)
+    const fixture: ComponentFixture<StickySegmentComponent> = TestBed.createComponent(StickySegmentComponent)
+    const component: StickySegmentComponent = fixture.componentInstance
+    component.segment = TestEntityFactory.createSegment()
     expect(component).toBeTruthy()
   })
 })
 
-function getMockedSegment(): Segment {
-  const mockedSegment = mock<Segment>()
-  when(mockedSegment.id).thenReturn('some-part-id')
-  when(mockedSegment.rundownId).thenReturn('some-rundown-id')
-  when(mockedSegment.name).thenReturn('some-segment-name')
-  when(mockedSegment.isOnAir).thenReturn(false)
-  when(mockedSegment.isNext).thenReturn(false)
-  when(mockedSegment.parts).thenReturn([])
-  return mockedSegment
-}
-
 async function configureTestBed(): Promise<void> {
-  const mockedOutputLayerService: Tv2OutputLayerService = mock<Tv2OutputLayerService>()
-  const mockedSegmentEntityService: SegmentEntityService = mock<SegmentEntityService>()
-  const mockedPartEntityService: PartEntityService = mock<PartEntityService>()
-  const mockedRundownService: RundownService = mock<RundownService>()
-  const mockIconService: IconService = mock<IconService>()
   await TestBed.configureTestingModule({
-    declarations: [SegmentComponent],
-    providers: [
-      { provide: Tv2OutputLayerService, useValue: instance(mockedOutputLayerService) },
-      { provide: SegmentEntityService, useValue: instance(mockedSegmentEntityService) },
-      { provide: PartEntityService, useValue: instance(mockedPartEntityService) },
-      { provide: RundownService, useValue: instance(mockedRundownService) },
-      { provide: IconService, useValue: instance(mockIconService) },
-      { provide: Logger, useValue: createLogger() },
-    ],
+    declarations: [StickySegmentComponent],
+    providers: [],
     imports: [SharedModule],
   }).compileComponents()
-}
-
-function createLogger(): Logger {
-  const testLoggerFactory: TestLoggerFactory = new TestLoggerFactory()
-  return testLoggerFactory.createLogger()
 }

--- a/src/app/rundown-view/components/sticky-segment/sticky-segment.component.spec.ts
+++ b/src/app/rundown-view/components/sticky-segment/sticky-segment.component.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing'
+import { Segment } from 'src/app/core/models/segment'
+
+import { SegmentComponent } from './sticky-segment.component'
+import { instance, mock, when } from '@typestrong/ts-mockito'
+import { Tv2OutputLayerService } from '../../../shared/services/tv2-output-layer.service'
+import { SegmentEntityService } from '../../../core/services/models/segment-entity.service'
+import { PartEntityService } from '../../../core/services/models/part-entity.service'
+import { RundownService } from '../../../core/abstractions/rundown.service'
+import { SharedModule } from '../../../shared/shared.module'
+import { Logger } from '../../../core/abstractions/logger.service'
+import { TestLoggerFactory } from '../../../test/factories/test-logger.factory'
+import { IconService } from 'src/app/core/abstractions/icon.service'
+
+describe('SegmentComponent', () => {
+  it('should create', async () => {
+    await configureTestBed()
+    const fixture = TestBed.createComponent(SegmentComponent)
+    const component = fixture.componentInstance
+    const mockedSegment = getMockedSegment()
+    component.segment = instance(mockedSegment)
+    expect(component).toBeTruthy()
+  })
+})
+
+function getMockedSegment(): Segment {
+  const mockedSegment = mock<Segment>()
+  when(mockedSegment.id).thenReturn('some-part-id')
+  when(mockedSegment.rundownId).thenReturn('some-rundown-id')
+  when(mockedSegment.name).thenReturn('some-segment-name')
+  when(mockedSegment.isOnAir).thenReturn(false)
+  when(mockedSegment.isNext).thenReturn(false)
+  when(mockedSegment.parts).thenReturn([])
+  return mockedSegment
+}
+
+async function configureTestBed(): Promise<void> {
+  const mockedOutputLayerService: Tv2OutputLayerService = mock<Tv2OutputLayerService>()
+  const mockedSegmentEntityService: SegmentEntityService = mock<SegmentEntityService>()
+  const mockedPartEntityService: PartEntityService = mock<PartEntityService>()
+  const mockedRundownService: RundownService = mock<RundownService>()
+  const mockIconService: IconService = mock<IconService>()
+  await TestBed.configureTestingModule({
+    declarations: [SegmentComponent],
+    providers: [
+      { provide: Tv2OutputLayerService, useValue: instance(mockedOutputLayerService) },
+      { provide: SegmentEntityService, useValue: instance(mockedSegmentEntityService) },
+      { provide: PartEntityService, useValue: instance(mockedPartEntityService) },
+      { provide: RundownService, useValue: instance(mockedRundownService) },
+      { provide: IconService, useValue: instance(mockIconService) },
+      { provide: Logger, useValue: createLogger() },
+    ],
+    imports: [SharedModule],
+  }).compileComponents()
+}
+
+function createLogger(): Logger {
+  const testLoggerFactory: TestLoggerFactory = new TestLoggerFactory()
+  return testLoggerFactory.createLogger()
+}

--- a/src/app/rundown-view/components/sticky-segment/sticky-segment.component.ts
+++ b/src/app/rundown-view/components/sticky-segment/sticky-segment.component.ts
@@ -27,9 +27,7 @@ export class StickySegmentComponent implements AfterViewInit, OnDestroy {
 
   private readonly intersectionObserver: IntersectionObserver
 
-  constructor(
-    private readonly hostElement: ElementRef,
-  ) {
+  constructor(private readonly hostElement: ElementRef) {
     this.intersectionObserver = this.createViewportIntersectionObserver()
   }
 

--- a/src/app/rundown-view/components/sticky-segment/sticky-segment.component.ts
+++ b/src/app/rundown-view/components/sticky-segment/sticky-segment.component.ts
@@ -1,0 +1,52 @@
+import { AfterViewInit, Component, ElementRef, Input, OnDestroy } from '@angular/core'
+import { Segment } from '../../../core/models/segment'
+
+@Component({
+  selector: 'sofie-sticky-segment',
+  templateUrl: './sticky-segment.component.html',
+  styleUrls: ['./sticky-segment.component.scss'],
+})
+export class StickySegmentComponent implements AfterViewInit, OnDestroy {
+  @Input()
+  public segment: Segment
+
+  @Input()
+  public isRundownActiveOrRehearsal: boolean
+
+  @Input()
+  public isAutoNextStarted: boolean
+
+  @Input()
+  public remainingDurationInMsForOnAirPart?: number
+
+  @Input()
+  public durationInMsUntilSegmentIsPutOnAir?: number
+
+  @Input()
+  public currentEpochTime: number
+
+  private readonly intersectionObserver: IntersectionObserver
+
+  constructor(
+    private readonly hostElement: ElementRef,
+  ) {
+    this.intersectionObserver = this.createViewportIntersectionObserver()
+  }
+
+  private createViewportIntersectionObserver(): IntersectionObserver {
+    return new IntersectionObserver(
+      ([event]): void => {
+        event.target.classList.toggle('stuck', event.intersectionRatio < 1)
+      },
+      { threshold: [1] }
+    )
+  }
+
+  public ngAfterViewInit(): void {
+    this.intersectionObserver.observe(this.hostElement.nativeElement)
+  }
+
+  public ngOnDestroy(): void {
+    this.intersectionObserver.disconnect()
+  }
+}

--- a/src/app/rundown-view/rundown-view.module.ts
+++ b/src/app/rundown-view/rundown-view.module.ts
@@ -36,6 +36,7 @@ import { MiniShelfCycleService } from './services/mini-shelf-cycle.service'
 import { MiniShelfNavigationService } from './services/mini-shelf-navigation.service'
 import { Tv2PieceTooltipContentFieldService } from './services/tv2-piece-tooltip-content-field.service'
 import { InvalidSegmentComponent } from './components/invalid-segment/invalid-segment.component'
+import { StickySegmentComponent } from './components/sticky-segment/sticky-segment.component'
 
 @NgModule({
   declarations: [
@@ -61,6 +62,7 @@ import { InvalidSegmentComponent } from './components/invalid-segment/invalid-se
     MiniShelfComponent,
     PieceTooltipComponent,
     InvalidSegmentComponent,
+    StickySegmentComponent,
   ],
   exports: [SegmentComponent],
   providers: [


### PR DESCRIPTION
Adds sticky segment component that is used by the rundown component to display an on air segment. The sticky segment is set with boundaries at the top and bottom of the viewport, sticking 1px outside of the viewport in order to detect when the segment sticks to the viewport boundary.
<img width="2052" alt="image" src="https://github.com/tv2/sofie-web-client/assets/11258272/f12b70ef-130c-4aba-833b-cd54d064f120">