### PR TITLE
SOF-2016: Show part invalidity

### DIFF
--- a/src/app/core/models/part.ts
+++ b/src/app/core/models/part.ts
@@ -1,5 +1,6 @@
 import { Piece } from './piece'
-import { AutoNext } from '../models/auto-next'
+import { AutoNext } from './auto-next'
+import { Invalidity } from './invalidity'
 
 export interface Part {
   readonly id: string
@@ -17,4 +18,5 @@ export interface Part {
   readonly isUntimed: boolean
   readonly metadata?: unknown
   readonly replacedPieces: readonly Piece[]
+  readonly invalidity?: Invalidity
 }

--- a/src/app/core/parsers/zod-entity-parser.service.ts
+++ b/src/app/core/parsers/zod-entity-parser.service.ts
@@ -66,6 +66,8 @@ export class ZodEntityParser implements EntityParser {
     }),
   })
 
+  private readonly invalidityParser = zod.object({ reason: zod.string() })
+
   private readonly partParser = zod.object({
     id: zod.string().min(1),
     rank: zod.number(),
@@ -89,6 +91,7 @@ export class ZodEntityParser implements EntityParser {
       })
       .optional(),
     replacedPieces: zod.array(this.pieceParser).default([]),
+    invalidity: this.invalidityParser.optional(),
   })
 
   private readonly segmentParser = zod.object({
@@ -110,7 +113,7 @@ export class ZodEntityParser implements EntityParser {
         miniShelfVideoClipFile: zod.string().optional(),
       })
       .optional(),
-    invalidity: zod.object({ reason: zod.string() }).optional(),
+    invalidity: this.invalidityParser.optional(),
   })
 
   private readonly basicRundownParser = zod.object({

--- a/src/app/rundown-view/components/attention-banner/attention-banner.component.html
+++ b/src/app/rundown-view/components/attention-banner/attention-banner.component.html
@@ -1,2 +1,5 @@
-<sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
-<span class="ms-1">{{ label }}</span>
+<div class="label">
+  <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
+  <span class="ms-1">{{ label }}</span>
+</div>
+<div *ngIf="description" class="description">{{ description }}</div>

--- a/src/app/rundown-view/components/attention-banner/attention-banner.component.html
+++ b/src/app/rundown-view/components/attention-banner/attention-banner.component.html
@@ -1,5 +1,5 @@
 <div class="label">
-  <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
+  <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M" [disabled]="true"></sofie-icon-button>
   <span class="ms-1">{{ label }}</span>
 </div>
 <div *ngIf="description" class="description">{{ description }}</div>

--- a/src/app/rundown-view/components/attention-banner/attention-banner.component.html
+++ b/src/app/rundown-view/components/attention-banner/attention-banner.component.html
@@ -1,0 +1,2 @@
+<sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
+<span class="ms-1">{{ label }}</span>

--- a/src/app/rundown-view/components/attention-banner/attention-banner.component.scss
+++ b/src/app/rundown-view/components/attention-banner/attention-banner.component.scss
@@ -1,0 +1,13 @@
+:host {
+  display: block;
+  padding: 4px 10px;
+  background-color: var(--attention-color);
+  color: var(--black-color);
+  font-size: 0.85rem;
+  font-weight: 500;
+  font-style: italic;
+
+  sofie-icon-button {
+    color: var(--black-color);
+  }
+}

--- a/src/app/rundown-view/components/attention-banner/attention-banner.component.scss
+++ b/src/app/rundown-view/components/attention-banner/attention-banner.component.scss
@@ -1,13 +1,26 @@
 :host {
   display: block;
-  padding: 4px 10px;
+  padding: 0.3rem 0.6rem;
   background-color: var(--attention-color);
   color: var(--black-color);
-  font-size: 0.85rem;
-  font-weight: 500;
-  font-style: italic;
 
   sofie-icon-button {
     color: var(--black-color);
+  }
+
+  .label {
+    font-weight: 500;
+  }
+
+  .description {
+    font-size: 0.85em;
+  }
+
+  &.small {
+    font-size: 0.85rem;
+  }
+
+  &.medium {
+    font-size: 1rem;
   }
 }

--- a/src/app/rundown-view/components/attention-banner/attention-banner.component.spec.ts
+++ b/src/app/rundown-view/components/attention-banner/attention-banner.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { AttentionBannerComponent } from './attention-banner.component'
+
+describe('AttentionBannerComponent', () => {
+  let component: AttentionBannerComponent
+  let fixture: ComponentFixture<AttentionBannerComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AttentionBannerComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(AttentionBannerComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/rundown-view/components/attention-banner/attention-banner.component.ts
+++ b/src/app/rundown-view/components/attention-banner/attention-banner.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core'
 import { Icon, IconSize } from '../../../shared/enums/icon'
 
 @Component({
@@ -8,8 +8,16 @@ import { Icon, IconSize } from '../../../shared/enums/icon'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AttentionBannerComponent {
-  @Input()
-  public label: string
   protected readonly Icon = Icon
   protected readonly IconSize = IconSize
+
+  @Input()
+  public label: string
+
+  @Input()
+  public description?: string
+
+  @Input()
+  @HostBinding('class')
+  public size: 'small' | 'medium' = 'medium'
 }

--- a/src/app/rundown-view/components/attention-banner/attention-banner.component.ts
+++ b/src/app/rundown-view/components/attention-banner/attention-banner.component.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import { Icon, IconSize } from '../../../shared/enums/icon'
+
+@Component({
+  selector: 'sofie-attention-banner',
+  templateUrl: './attention-banner.component.html',
+  styleUrls: ['./attention-banner.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AttentionBannerComponent {
+  @Input()
+  public label: string
+  protected readonly Icon = Icon
+  protected readonly IconSize = IconSize
+}

--- a/src/app/rundown-view/components/follow-playhead-timeline/follow-playhead-timeline.component.scss
+++ b/src/app/rundown-view/components/follow-playhead-timeline/follow-playhead-timeline.component.scss
@@ -5,5 +5,6 @@
 
   .parts {
     display: inline-flex;
+    height: 100%;
   }
 }

--- a/src/app/rundown-view/components/invalid-segment/invalid-segment.component.html
+++ b/src/app/rundown-view/components/invalid-segment/invalid-segment.component.html
@@ -5,13 +5,9 @@
             {{ segment.referenceTag }}
           </span>
         </div>
-        <div class="invalid p-2 pt-1 pb-1">
-            <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M" [disabled]="true"></sofie-icon-button>
-            <span class="ms-1">INVALID</span>
-            <div class="text">
-                {{ segment.invalidity?.reason }}
-            </div>
-        </div>
+
+        <sofie-attention-banner i18n-label label="invalid-segment.invalid.label" [description]="segment.invalidity?.reason"></sofie-attention-banner>
+
         <div class="title m-2">
             {{ segment.name }}
         </div>

--- a/src/app/rundown-view/components/invalid-segment/invalid-segment.component.scss
+++ b/src/app/rundown-view/components/invalid-segment/invalid-segment.component.scss
@@ -27,17 +27,6 @@
       }
     }
 
-    .invalid {
-      background: var(--attention-color);
-      color: var(--black-color);
-      font-size: 1rem;
-      font-weight: 500;
-
-      sofie-icon-button {
-        color: var(--black-color);
-      }
-    }
-
     .title {
       color: var(--text-color);
       font-size: 1.4em;

--- a/src/app/rundown-view/components/offsetable-part/offsetable-part.component.html
+++ b/src/app/rundown-view/components/offsetable-part/offsetable-part.component.html
@@ -1,4 +1,4 @@
-<div [cdkContextMenuTriggerFor]="contextMenu" class="piece-layers" [class.unsynced]="part.isUnsynced">
+<div [cdkContextMenuTriggerFor]="contextMenu" class="piece-layers" [class.unsynced]="part.isUnsynced" [class.invalid]="part.invalidity" sofieTooltip [sofieTooltipTemplate]="tooltipTemplate">
   <div *ngFor="let outputLayer of outputLayers" class="piece-layer">
     <sofie-offsetable-piece
       *ngFor="let piece of piecesGroupedByOutputLayer[outputLayer]; trackBy: trackPiece"
@@ -15,4 +15,8 @@
 
 <ng-template #contextMenu>
   <sofie-part-context-menu *ngIf="isRundownActiveOrRehearsal" [part]="part" [rundownId]="rundownId"></sofie-part-context-menu>
+</ng-template>
+
+<ng-template #tooltipTemplate>
+  <sofie-invalid-part-tooltip *ngIf="part.invalidity" [invalidity]="part.invalidity"></sofie-invalid-part-tooltip>
 </ng-template>

--- a/src/app/rundown-view/components/offsetable-part/offsetable-part.component.scss
+++ b/src/app/rundown-view/components/offsetable-part/offsetable-part.component.scss
@@ -29,6 +29,7 @@
       bottom: 0;
       left: 0;
       background: var(--unsynced-part-linear-gradient);
+      opacity: .4;
       z-index: 10;
     }
   }
@@ -42,12 +43,12 @@
       bottom: 0;
       left: 0;
       background:
-        linear-gradient(to bottom right, #00000000, #00000000 43%, var(--attention-color) 43%, var(--attention-color) 57%, #00000000 57%, #00000000 100%),
-        linear-gradient(to top right, #00000000, #00000000 43%, var(--attention-color) 43%, var(--attention-color) 57%, #00000000 57%, #00000000 100%),
-        linear-gradient(to bottom right, #00000000, #00000000 44%, var(--background-color) 44%, var(--background-color) 58%, #00000000 60%, #00000000 100%)
+        linear-gradient(to bottom right, var(--transparent-color), var(--transparent-color) 43%, var(--attention-color) 43%, var(--attention-color) 57%, var(--transparent-color) 57%, var(--transparent-color) 100%),
+        linear-gradient(to top right, var(--transparent-color), var(--transparent-color) 43%, var(--attention-color) 43%, var(--attention-color) 57%, var(--transparent-color) 57%, var(--transparent-color) 100%),
+        linear-gradient(to bottom right, var(--transparent-color), var(--transparent-color) 44%, var(--background-color) 44%, var(--background-color) 58%, var(--transparent-color) 60%, var(--transparent-color) 100%)
       ;
-      background-size: 16px 16px;
-      opacity: .8;
+      background-size: 14px 14px;
+      opacity: .7;
       z-index: 10;
     }
   }

--- a/src/app/rundown-view/components/offsetable-part/offsetable-part.component.scss
+++ b/src/app/rundown-view/components/offsetable-part/offsetable-part.component.scss
@@ -32,4 +32,23 @@
       z-index: 10;
     }
   }
+
+  .invalid {
+    &:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background:
+        linear-gradient(to bottom right, #00000000, #00000000 43%, var(--attention-color) 43%, var(--attention-color) 57%, #00000000 57%, #00000000 100%),
+        linear-gradient(to top right, #00000000, #00000000 43%, var(--attention-color) 43%, var(--attention-color) 57%, #00000000 57%, #00000000 100%),
+        linear-gradient(to bottom right, #00000000, #00000000 44%, var(--background-color) 44%, var(--background-color) 58%, #00000000 60%, #00000000 100%)
+      ;
+      background-size: 16px 16px;
+      opacity: .8;
+      z-index: 10;
+    }
+  }
 }

--- a/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.html
@@ -1,0 +1,2 @@
+<sofie-attention-banner i18n-label label="invalid-part-tooltip.invalid-part.label"></sofie-attention-banner>
+<div class="pt-1 pb-1 ps-2 pe-2">{{ invalidity.reason }}</div>

--- a/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.html
@@ -1,2 +1,2 @@
-<sofie-attention-banner i18n-label label="invalid-part-tooltip.invalid-part.label"></sofie-attention-banner>
+<sofie-attention-banner i18n-label label="invalid-part-tooltip.invalid-part.label" size="small"></sofie-attention-banner>
 <div class="pt-1 pb-1 ps-2 pe-2">{{ invalidity.reason }}</div>

--- a/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.scss
+++ b/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.scss
@@ -1,0 +1,4 @@
+:host {
+  color: var(--white-color);
+  font-size: 0.85rem;
+}

--- a/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.spec.ts
+++ b/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { instance, mock } from '@typestrong/ts-mockito'
+import { InvalidPartTooltipComponent } from './invalid-part-tooltip.component'
+import { ChangeDetectorRef } from '@angular/core'
+import { Tv2PieceTooltipContentFieldService } from '../../../services/tv2-piece-tooltip-content-field.service'
+
+describe('InvalidPartTooltipComponent', () => {
+  let component: InvalidPartTooltipComponent
+  let fixture: ComponentFixture<InvalidPartTooltipComponent>
+
+  beforeEach(async () => {
+    const mockChangeDetectorRef: ChangeDetectorRef = mock<ChangeDetectorRef>()
+    const mockPieceTooltipContentFieldService: Tv2PieceTooltipContentFieldService = mock<Tv2PieceTooltipContentFieldService>()
+    await TestBed.configureTestingModule({
+      declarations: [InvalidPartTooltipComponent],
+      providers: [
+        { provide: ChangeDetectorRef, useValue: instance(mockChangeDetectorRef) },
+        { provide: Tv2PieceTooltipContentFieldService, useValue: instance(mockPieceTooltipContentFieldService) },
+      ],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(InvalidPartTooltipComponent)
+    component = fixture.componentInstance
+  })
+
+  it('should create', () => {
+    component.invalidity = { reason: 'The invalidity reason' }
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.ts
+++ b/src/app/rundown-view/components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core'
+import { Icon, IconSize } from '../../../../shared/enums/icon'
+import { Invalidity } from '../../../../core/models/invalidity'
+
+@Component({
+  selector: 'sofie-invalid-part-tooltip',
+  templateUrl: './invalid-part-tooltip.component.html',
+  styleUrls: ['./invalid-part-tooltip.component.scss'],
+})
+export class InvalidPartTooltipComponent {
+  protected readonly Icon = Icon
+  protected readonly IconSize = IconSize
+
+  @Input() public invalidity: Invalidity
+}

--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
@@ -11,7 +11,7 @@
       <span class="label">{{piece.name}}</span>
     </header>
 
-    <sofie-attention-banner *ngIf="hasPieceMedia() && !media" i18n-label label="piece-tooltip.source-unavailable.label"></sofie-attention-banner>
+    <sofie-attention-banner *ngIf="hasPieceMedia() && !media" i18n-label label="piece-tooltip.source-unavailable.label" size="small"></sofie-attention-banner>
 
     <div class="content-fields">
       <div *ngFor="let field of tooltipContentFields" class="field">

--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.html
@@ -7,21 +7,18 @@
   </sofie-video-hover-scrub>
 
   <div class="tooltip-body">
-      <header [class]="getPieceColorClass()">
-          <span class="label">{{piece.name}}</span>
-      </header>
+    <header [class]="getPieceColorClass()">
+      <span class="label">{{piece.name}}</span>
+    </header>
 
-      <div *ngIf="hasPieceMedia() && !media" class="source-unavailable-banner">
-        <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
-        <span class="ms-1" i18n>piece-tooltip.source-unavailable.label</span>
-      </div>
+    <sofie-attention-banner *ngIf="hasPieceMedia() && !media" i18n-label label="piece-tooltip.source-unavailable.label"></sofie-attention-banner>
 
-      <div class="content-fields">
-          <div *ngFor="let field of tooltipContentFields" class="field">
-              <span class="label">{{field.label}}:</span>
-              <span class="value">{{field.value}}</span>
-          </div>
+    <div class="content-fields">
+      <div *ngFor="let field of tooltipContentFields" class="field">
+        <span class="label">{{field.label}}:</span>
+        <span class="value">{{field.value}}</span>
       </div>
+    </div>
   </div>
 </div>
 

--- a/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.scss
+++ b/src/app/rundown-view/components/rundown-tooltips/piece-tooltip/piece-tooltip.component.scss
@@ -17,18 +17,6 @@
     }
   }
 
-  .source-unavailable-banner {
-    padding: 4px 10px;
-    background-color: var(--attention-color);
-    font-size: 0.85rem;
-    font-weight: 500;
-    font-style: italic;
-
-    sofie-icon-button {
-      color: var(--black-color);
-    }
-  }
-
   .content-fields {
     display: grid;
     grid-template-columns: auto auto;

--- a/src/app/rundown-view/components/scrollable-timeline/scrollable-timeline.component.scss
+++ b/src/app/rundown-view/components/scrollable-timeline/scrollable-timeline.component.scss
@@ -10,5 +10,6 @@
 
   .parts {
     display: inline-flex;
+    height: 100%;
   }
 }

--- a/src/app/rundown-view/components/segment/segment.component.html
+++ b/src/app/rundown-view/components/segment/segment.component.html
@@ -17,10 +17,9 @@
         ></sofie-countdown-label>
       </span>
     </div>
-    <div *ngIf="segment.isUnsynced" class="unsynced">
-      <sofie-icon-button [icon]="Icon.TRIANGLE_EXCLAMATION" [iconSize]="IconSize.M"></sofie-icon-button>
-      <span class="ms-1">UNSYNCED</span>
-    </div>
+
+    <sofie-attention-banner *ngIf="segment.isUnsynced" i18n-label label="segment.unsynced.label"></sofie-attention-banner>
+
     <div class="title">
       {{ segment.name }}
     </div>

--- a/src/app/rundown-view/components/segment/segment.component.scss
+++ b/src/app/rundown-view/components/segment/segment.component.scss
@@ -54,18 +54,6 @@
     }
   }
 
-  .unsynced {
-    padding: 4px 10px;
-    background: var(--rundown-unsynced-segment-color);
-    color: var(--black-color);
-    font-size: 1rem;
-    font-weight: 500;
-
-    sofie-icon-button {
-      color: var(--black-color);
-    }
-  }
-
   .title {
     padding: 7px;
     color: var(--text-color);

--- a/src/app/rundown-view/rundown-view.module.ts
+++ b/src/app/rundown-view/rundown-view.module.ts
@@ -36,6 +36,7 @@ import { MiniShelfCycleService } from './services/mini-shelf-cycle.service'
 import { MiniShelfNavigationService } from './services/mini-shelf-navigation.service'
 import { Tv2PieceTooltipContentFieldService } from './services/tv2-piece-tooltip-content-field.service'
 import { InvalidSegmentComponent } from './components/invalid-segment/invalid-segment.component'
+import { AttentionBannerComponent } from './components/attention-banner/attention-banner.component'
 
 @NgModule({
   declarations: [
@@ -61,6 +62,7 @@ import { InvalidSegmentComponent } from './components/invalid-segment/invalid-se
     MiniShelfComponent,
     PieceTooltipComponent,
     InvalidSegmentComponent,
+    AttentionBannerComponent,
   ],
   exports: [SegmentComponent],
   providers: [

--- a/src/app/rundown-view/rundown-view.module.ts
+++ b/src/app/rundown-view/rundown-view.module.ts
@@ -37,6 +37,9 @@ import { MiniShelfNavigationService } from './services/mini-shelf-navigation.ser
 import { Tv2PieceTooltipContentFieldService } from './services/tv2-piece-tooltip-content-field.service'
 import { InvalidSegmentComponent } from './components/invalid-segment/invalid-segment.component'
 import { AttentionBannerComponent } from './components/attention-banner/attention-banner.component'
+import {
+  InvalidPartTooltipComponent
+} from './components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component'
 
 @NgModule({
   declarations: [
@@ -63,6 +66,7 @@ import { AttentionBannerComponent } from './components/attention-banner/attentio
     PieceTooltipComponent,
     InvalidSegmentComponent,
     AttentionBannerComponent,
+    InvalidPartTooltipComponent,
   ],
   exports: [SegmentComponent],
   providers: [

--- a/src/app/rundown-view/rundown-view.module.ts
+++ b/src/app/rundown-view/rundown-view.module.ts
@@ -37,9 +37,7 @@ import { MiniShelfNavigationService } from './services/mini-shelf-navigation.ser
 import { Tv2PieceTooltipContentFieldService } from './services/tv2-piece-tooltip-content-field.service'
 import { InvalidSegmentComponent } from './components/invalid-segment/invalid-segment.component'
 import { AttentionBannerComponent } from './components/attention-banner/attention-banner.component'
-import {
-  InvalidPartTooltipComponent
-} from './components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component'
+import { InvalidPartTooltipComponent } from './components/rundown-tooltips/invalid-part-tooltip/invalid-part-tooltip.component'
 
 @NgModule({
   declarations: [

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -56,451 +56,455 @@
       </trans-unit>
       <trans-unit id="7774679192134693239" datatype="html">
         <source>rundown-overview.settings.title</source>
-        <target state="new">Indstillinger</target>
+        <target>Indstillinger</target>
       </trans-unit>
       <trans-unit id="4380077604653787346" datatype="html">
         <source>settings.clear-cache.label</source>
-        <target state="new">Ryd cache</target>
+        <target>Ryd cache</target>
       </trans-unit>
       <trans-unit id="7618983089240067205" datatype="html">
         <source>action-triggers.shortcut.label</source>
-        <target state="new">Shortcut</target>
+        <target>Shortcut</target>
       </trans-unit>
       <trans-unit id="1532790028301204513" datatype="html">
         <source>global.delete.label</source>
-        <target state="new">Delete</target>
+        <target>Delete</target>
       </trans-unit>
       <trans-unit id="386627600927064568" datatype="html">
         <source>keyboard-mapping.delete-selected.confirmation</source>
-        <target state="new">Are you sure you want to delete all selected Keyboard Mappings?</target>
+        <target>Are you sure you want to delete all selected Keyboard Mappings?</target>
       </trans-unit>
       <trans-unit id="6285874749005785753" datatype="html">
         <source>global.label</source>
-        <target state="new">Label</target>
+        <target>Label</target>
       </trans-unit>
       <trans-unit id="9004520789605873710" datatype="html">
         <source>global.close.button</source>
-        <target state="new">Close</target>
+        <target>Close</target>
       </trans-unit>
       <trans-unit id="5199708374936679830" datatype="html">
         <source>global.delete-selected.label</source>
-        <target state="new">Delete selected</target>
+        <target>Delete selected</target>
       </trans-unit>
       <trans-unit id="9158000000301348817" datatype="html">
         <source>action-triggers.trigger-on.label</source>
-        <target state="new">Trigger on</target>
+        <target>Trigger on</target>
       </trans-unit>
       <trans-unit id="5943393457796095490" datatype="html">
         <source>action-triggers.physical-mapping.label</source>
-        <target state="new">Physical mapping</target>
+        <target>Physical mapping</target>
       </trans-unit>
       <trans-unit id="5384713853490936899" datatype="html">
         <source>clear-cache.title</source>
-        <target state="new">Clear cache</target>
+        <target>Clear cache</target>
       </trans-unit>
       <trans-unit id="7955116266682092985" datatype="html">
         <source>clear-cache.button.label</source>
-        <target state="new">Clear configuration cache</target>
+        <target>Clear configuration cache</target>
       </trans-unit>
       <trans-unit id="7840343495376792564" datatype="html">
         <source>global.confirmation.label</source>
-        <target state="new">Confirmation</target>
+        <target>Confirmation</target>
       </trans-unit>
       <trans-unit id="6681316063292517711" datatype="html">
         <source>clear-cache.clear.confirmation</source>
-        <target state="new">Are you sure you want to clear your cache?</target>
+        <target>Are you sure you want to clear your cache?</target>
       </trans-unit>
       <trans-unit id="1544567860044151272" datatype="html">
         <source>global.clear.label</source>
-        <target state="new">Clear</target>
+        <target>Clear</target>
       </trans-unit>
       <trans-unit id="9191550720479888548" datatype="html">
         <source>settings.keyboard-mappings.title</source>
-        <target state="new">Keyboard mappings</target>
+        <target>Keyboard mappings</target>
       </trans-unit>
       <trans-unit id="4177582797246824978" datatype="html">
         <source>action-triggers.physical-mapping-help.tooltip</source>
-        <target state="new">The physical key combination that should be shown on the virtual keyboard in the rundown view. The field should only be used if the key combination is altered by a key mapping software like AutoHotKey.</target>
+        <target>The physical key combination that should be shown on the virtual keyboard in the rundown view. The field should only be used if the key combination is altered by a key mapping software like AutoHotKey.</target>
       </trans-unit>
       <trans-unit id="9012317992372082365" datatype="html">
         <source>global.next.label</source>
-        <target state="new">NEXT</target>
+        <target>NEXT</target>
       </trans-unit>
       <trans-unit id="5184481909550121889" datatype="html">
         <source>global.auto.label</source>
-        <target state="new">AUTO</target>
+        <target>AUTO</target>
       </trans-unit>
       <trans-unit id="4384831734174772961" datatype="html">
         <source>settings.shelf.label</source>
-        <target state="new">Shelf</target>
+        <target>Shelf</target>
       </trans-unit>
       <trans-unit id="4302180445374821108" datatype="html">
         <source>settings.shelf.action-panels.title</source>
-        <target state="new">Shelf Action panels</target>
+        <target>Shelf Action panels</target>
       </trans-unit>
       <trans-unit id="2803021013738697812" datatype="html">
         <source>global.create.label</source>
-        <target state="new">Create</target>
+        <target>Create</target>
       </trans-unit>
       <trans-unit id="6050389772118678864" datatype="html">
         <source>global.export.label</source>
-        <target state="new">Export</target>
+        <target>Export</target>
       </trans-unit>
       <trans-unit id="621872648794619093" datatype="html">
         <source>piece.lifespan.within-part</source>
-        <target state="new">Indeni parten</target>
+        <target>Indeni parten</target>
       </trans-unit>
       <trans-unit id="1624699664203091977" datatype="html">
         <source>piece.lifespan.sticky-until-segment-change</source>
-        <target state="new">Bliver indtil ændret i segmentet</target>
+        <target>Bliver indtil ændret i segmentet</target>
       </trans-unit>
       <trans-unit id="8704971237918811774" datatype="html">
         <source>piece.lifespan.sticky-until-segment-end</source>
-        <target state="new">Bliver indtil segment slutter</target>
+        <target>Bliver indtil segment slutter</target>
       </trans-unit>
       <trans-unit id="1512530649495667717" datatype="html">
         <source>piece.lifespan.sticky-until-rundown-change</source>
-        <target state="new">Bliver indtil ændret i rundown</target>
+        <target>Bliver indtil ændret i rundown</target>
       </trans-unit>
       <trans-unit id="249423270498322985" datatype="html">
         <source>action-panel.panel-name.label</source>
-        <target state="new">Panel name</target>
+        <target>Panel name</target>
       </trans-unit>
       <trans-unit id="7630473968632852036" datatype="html">
         <source>piece.lifespan.spanning-until-rundown-end</source>
-        <target state="new">Spænder indtil rundown slutter</target>
+        <target>Spænder indtil rundown slutter</target>
       </trans-unit>
       <trans-unit id="3495993720885162413" datatype="html">
         <source>action-panel.rank.label</source>
-        <target state="new">Rank</target>
+        <target>Rank</target>
       </trans-unit>
       <trans-unit id="558457345008559478" datatype="html">
         <source>piece.lifespan.start-spanning-segment-then-sticky-rundown</source>
-        <target state="new">Spænder segmentet og bliver så på rundown</target>
+        <target>Spænder segmentet og bliver så på rundown</target>
       </trans-unit>
       <trans-unit id="1842982718967386055" datatype="html">
         <source>global.audio.label</source>
-        <target state="new">Audio</target>
+        <target>Audio</target>
       </trans-unit>
       <trans-unit id="1016737278364313295" datatype="html">
         <source>piece.lifespan.unknown</source>
-        <target state="new">Ukendt</target>
+        <target>Ukendt</target>
       </trans-unit>
       <trans-unit id="389262478828731921" datatype="html">
         <source>global.remote.label</source>
-        <target state="new">Remote</target>
+        <target>Remote</target>
       </trans-unit>
       <trans-unit id="1146669822886669522" datatype="html">
         <source>piece-tooltip-content.name.label</source>
-        <target state="new">Navn</target>
+        <target>Navn</target>
       </trans-unit>
       <trans-unit id="6046979654633268329" datatype="html">
         <source>global.camera.label</source>
-        <target state="new">Camera</target>
+        <target>Camera</target>
       </trans-unit>
       <trans-unit id="4345807184627930663" datatype="html">
         <source>piece-tooltip-content.name-of-clip.label</source>
-        <target state="new">Klip navn</target>
+        <target>Klip navn</target>
       </trans-unit>
       <trans-unit id="2951845926043442554" datatype="html">
         <source>global.graphics.label</source>
-        <target state="new">Graphics</target>
+        <target>Graphics</target>
       </trans-unit>
       <trans-unit id="6258196151878366535" datatype="html">
         <source>piece-tooltip-content.name-of-pilot.label</source>
-        <target state="new">Navn på pilot</target>
+        <target>Navn på pilot</target>
       </trans-unit>
       <trans-unit id="8361312030303141039" datatype="html">
         <source>global.replay.label</source>
-        <target state="new">Replay</target>
+        <target>Replay</target>
       </trans-unit>
       <trans-unit id="1887044897982242749" datatype="html">
         <source>global.robot.label</source>
-        <target state="new">Robot</target>
+        <target>Robot</target>
       </trans-unit>
       <trans-unit id="7053378516611820006" datatype="html">
         <source>global.split-screen.label</source>
-        <target state="new">Split screen</target>
+        <target>Split screen</target>
       </trans-unit>
       <trans-unit id="8633433908703192113" datatype="html">
         <source>global.transition.label</source>
-        <target state="new">Transition</target>
+        <target>Transition</target>
       </trans-unit>
       <trans-unit id="8164633860480723989" datatype="html">
         <source>global.unknown.label</source>
-        <target state="new">Unknown</target>
+        <target>Unknown</target>
       </trans-unit>
       <trans-unit id="3522238577113202288" datatype="html">
         <source>global.video-clip.label</source>
-        <target state="new">Video clip</target>
+        <target>Video clip</target>
       </trans-unit>
       <trans-unit id="5944821486251382171" datatype="html">
         <source>global.filters.label</source>
-        <target state="new">Filters</target>
+        <target>Filters</target>
       </trans-unit>
       <trans-unit id="125592769491380843" datatype="html">
         <source>action-panel.delete.confirmation</source>
-        <target state="new">Er du sikker på at du vil slette dette panel?</target>
+        <target>Er du sikker på at du vil slette dette panel?</target>
       </trans-unit>
       <trans-unit id="4121868262213030663" datatype="html">
         <source>global.import.button</source>
-        <target state="new">Import</target>
+        <target>Import</target>
       </trans-unit>
       <trans-unit id="1489043303962671570" datatype="html">
         <source>keyboard-mapping.delete.confirmation</source>
-        <target state="new">Er du sikker på at du vil slette denne genvej?</target>
+        <target>Er du sikker på at du vil slette denne genvej?</target>
       </trans-unit>
       <trans-unit id="1426591653041922259" datatype="html">
         <source>edit-keyboard-mapping.edit</source>
-        <target state="new">Rediger genvej</target>
+        <target>Rediger genvej</target>
       </trans-unit>
       <trans-unit id="1469306793833284818" datatype="html">
         <source>edit-keyboard-mapping.create</source>
-        <target state="new">Opret genvej</target>
+        <target>Opret genvej</target>
       </trans-unit>
       <trans-unit id="3570927086139625658" datatype="html">
         <source>edit-shelf-action-panel-configuration.edit</source>
-        <target state="new">Rediger Action Panel konfiguration</target>
+        <target>Rediger Action Panel konfiguration</target>
       </trans-unit>
       <trans-unit id="7388536117729067" datatype="html">
         <source>edit-shelf-action-panel-configuration.create</source>
-        <target state="new">Opret Action Panel konfiguration</target>
+        <target>Opret Action Panel konfiguration</target>
       </trans-unit>
       <trans-unit id="8113227000238039449" datatype="html">
         <source>empty.table</source>
-        <target state="new">Ingen data fundet</target>
+        <target>Ingen data fundet</target>
       </trans-unit>
       <trans-unit id="377801051239310294" datatype="html">
         <source>rundown-overview-component.planned-start</source>
-        <target state="new">Planlagt start</target>
+        <target>Planlagt start</target>
       </trans-unit>
       <trans-unit id="1759269174172455303" datatype="html">
         <source>rundown-overview-component.duration</source>
-        <target state="new">Varighed</target>
+        <target>Varighed</target>
       </trans-unit>
       <trans-unit id="5719401361944025947" datatype="html">
         <source>rundown-overview-component.planned-end</source>
-        <target state="new">Planlagt slut</target>
+        <target>Planlagt slut</target>
       </trans-unit>
       <trans-unit id="265486137243693578" datatype="html">
         <source>common-search</source>
-        <target state="new">Søg</target>
+        <target>Søg</target>
       </trans-unit>
       <trans-unit id="7507229359295852513" datatype="html">
         <source>keyboard-mapping-settings-page.edit-action-panel</source>
-        <target state="new">Rediger Action panel</target>
+        <target>Rediger Action panel</target>
       </trans-unit>
       <trans-unit id="4970317883878168308" datatype="html">
         <source>keyboard-mapping-settings-page.copy-action-panel</source>
-        <target state="new">Dupliker Action panel</target>
+        <target>Dupliker Action panel</target>
       </trans-unit>
       <trans-unit id="6885589310720431669" datatype="html">
         <source>keyboard-mapping-settings-page.delete-action-panel</source>
-        <target state="new">Slet Action panel</target>
+        <target>Slet Action panel</target>
       </trans-unit>
       <trans-unit id="8250191741920581081" datatype="html">
         <source>action-selector.select-action</source>
-        <target state="new">Vælg en Action</target>
+        <target>Vælg en Action</target>
       </trans-unit>
       <trans-unit id="1039010698457393444" datatype="html">
         <source>action-selector.search-action</source>
-        <target state="new">Søg efter en Action</target>
+        <target>Søg efter en Action</target>
       </trans-unit>
       <trans-unit id="985670024801490264" datatype="html">
         <source>keyboard-mapping-settings-page.delete-keyboard-mapping.success</source>
-        <target state="new">Genvejen blev slettet</target>
+        <target>Genvejen blev slettet</target>
       </trans-unit>
       <trans-unit id="3545744709165250098" datatype="html">
         <source>keyboard-mapping-settings-page.duplicate-keyboard-mapping.success</source>
-        <target state="new">Genvejen blev duplikeret</target>
+        <target>Genvejen blev duplikeret</target>
       </trans-unit>
       <trans-unit id="7491316453773946580" datatype="html">
         <source>keyboard-mapping-settings-page.create-keyboard-mapping.success</source>
-        <target state="new">Genvejen blev oprettet</target>
+        <target>Genvejen blev oprettet</target>
       </trans-unit>
       <trans-unit id="4004671805035160284" datatype="html">
         <source>keyboard-mapping-settings-page.update-keyboard-mapping.success</source>
-        <target state="new">Genvejen blev opdateret</target>
+        <target>Genvejen blev opdateret</target>
       </trans-unit>
       <trans-unit id="6679898506590591687" datatype="html">
         <source>keyboard-mapping-settings-page.import-keyboard-mappings.success</source>
-        <target state="new">Genvejene blev importeret</target>
+        <target>Genvejene blev importeret</target>
       </trans-unit>
       <trans-unit id="2265780212602106942" datatype="html">
         <source>keyboard-mapping-settings-page.delete-all-keyboard-mappings.fail</source>
-        <target state="new">Noget gik galt under sletning af genvejene</target>
+        <target>Noget gik galt under sletning af genvejene</target>
       </trans-unit>
       <trans-unit id="976917377731196434" datatype="html">
         <source>shelf-action-panel-settings-page.create-action-panel.success <x id="PH" equiv-text="createdActionPanel.name"/></source>
-        <target state="new">Action panelet: <x id="PH" equiv-text="result.name"/> blev oprettet</target>
+        <target>Action panelet: <x id="PH" equiv-text="result.name"/> blev oprettet</target>
       </trans-unit>
       <trans-unit id="4084730079945397668" datatype="html">
         <source>shelf-action-panel-settings.page.update-action-panel.success <x id="PH" equiv-text="updatedActionPanel.name"/></source>
-        <target state="new">Action panelet: <x id="PH" equiv-text="result.name"/> blev opdateret</target>
+        <target>Action panelet: <x id="PH" equiv-text="result.name"/> blev opdateret</target>
       </trans-unit>
       <trans-unit id="2441219618501183432" datatype="html">
         <source>shelf-action-panel-settings-page.selected-action-panels.deleted</source>
-        <target state="new">De valgte Action paneler blev slettet</target>
+        <target>De valgte Action paneler blev slettet</target>
       </trans-unit>
       <trans-unit id="5114970090218136617" datatype="html">
         <source>common.save</source>
-        <target state="new">Gem</target>
+        <target>Gem</target>
       </trans-unit>
       <trans-unit id="247703202619960491" datatype="html">
         <source>piece-tooltip-content.template-name.label</source>
-        <target state="new">Navn på skabelon</target>
+        <target>Navn på skabelon</target>
       </trans-unit>
       <trans-unit id="2286645272575381009" datatype="html">
         <source>piece-tooltip-content.content-of-all-fields.label</source>
-        <target state="new">Indhold af alle felter</target>
+        <target>Indhold af alle felter</target>
       </trans-unit>
       <trans-unit id="1962663410998124131" datatype="html">
         <source>piece-tooltip-content.duration.label</source>
-        <target state="new">Varighed</target>
+        <target>Varighed</target>
       </trans-unit>
       <trans-unit id="2911851896669162406" datatype="html">
         <source>piece-tooltip-content.available-for-playout.label</source>
-        <target state="new">Kan afspilles</target>
+        <target>Kan afspilles</target>
       </trans-unit>
       <trans-unit id="1044477716904098041" datatype="html">
         <source>piece-tooltip-content.time-code-in-part.label</source>
-        <target state="new">Tid afspillet i part</target>
+        <target>Tid afspillet i part</target>
       </trans-unit>
       <trans-unit id="3000985957863398667" datatype="html">
         <source>piece-tooltip-content.out-type.label</source>
-        <target state="new">Udgangstype</target>
+        <target>Udgangstype</target>
       </trans-unit>
       <trans-unit id="8147260465029418817" datatype="html">
         <source>piece-tooltip-content.unknown.data</source>
-        <target state="new">Ukendt</target>
+        <target>Ukendt</target>
       </trans-unit>
       <trans-unit id="4174829375203668461" datatype="html">
         <source>piece-tooltip-content.no-specific-time-code.data</source>
-        <target state="new">(Ingen specifik tidskode))</target>
+        <target>(Ingen specifik tidskode))</target>
       </trans-unit>
       <trans-unit id="717945474169849731" datatype="html">
         <source>global.yes</source>
-        <target state="new">Ja</target>
+        <target>Ja</target>
       </trans-unit>
       <trans-unit id="8248235614614318568" datatype="html">
         <source>global.no</source>
-        <target state="new">Nej</target>
+        <target>Nej</target>
       </trans-unit>
       <trans-unit id="3623062952070884482" datatype="html">
         <source>piece-tooltip.source-unavailable.label</source>
-        <target state="new">Kilden er utilgængelig!</target>
+        <target>Kilden er utilgængelig!</target>
       </trans-unit>
       <trans-unit id="8873287033928471003" datatype="html">
         <source>keyboard-mapping-settings-page.import-keyboard-mappings.failure</source>
-        <target state="new">Noget gik galt under importeringen af genveje</target>
+        <target>Noget gik galt under importeringen af genveje</target>
       </trans-unit>
       <trans-unit id="8291594485469554782" datatype="html">
         <source>notification-icon.toggle-panel.tooltip</source>
-        <target state="new">Klik for at vise/skjule notifikationspanelet</target>
+        <target>Klik for at vise/skjule notifikationspanelet</target>
       </trans-unit>
       <trans-unit id="3299373246271290710" datatype="html">
         <source>action-triggers.action.label</source>
-        <target state="new">Action</target>
+        <target>Action</target>
       </trans-unit>
       <trans-unit id="719177318571875364" datatype="html">
         <source>common.form-required-field.button-tooltip</source>
-        <target state="new">Please fill out the required field(s).</target>
+        <target>Please fill out the required field(s).</target>
       </trans-unit>
       <trans-unit id="5742386463554387927" datatype="html">
         <source>action-triggers.shortcut.error</source>
-        <target state="new">A shortcut is required.</target>
+        <target>A shortcut is required.</target>
       </trans-unit>
       <trans-unit id="6359779760013296434" datatype="html">
         <source>action-triggers.trigger-on.error</source>
-        <target state="new">Please select how the shortcut should trigger.</target>
+        <target>Please select how the shortcut should trigger.</target>
       </trans-unit>
       <trans-unit id="6127544094154745108" datatype="html">
         <source><x id="PH" equiv-text="this.selectedAction?.argument?.name"/> action-triggers.action-arguments.error</source>
-        <target state="new"><x id="PH" equiv-text="this.selectedAction?.argument?.name!"/> is required.</target>
+        <target><x id="PH" equiv-text="this.selectedAction?.argument?.name!"/> is required.</target>
       </trans-unit>
       <trans-unit id="979335411678822239" datatype="html">
         <source>action-panel.name.error</source>
-        <target state="new">Please fill out a name.</target>
+        <target>Please fill out a name.</target>
       </trans-unit>
       <trans-unit id="5202318571157878044" datatype="html">
         <source>action-panel.action-filter.error</source>
-        <target state="new">Select at least one filter.</target>
+        <target>Select at least one filter.</target>
       </trans-unit>
       <trans-unit id="770599904666863258" datatype="html">
         <source>action-panel.rank.error</source>
-        <target state="new">The panel must have a rank provided.</target>
+        <target>The panel must have a rank provided.</target>
       </trans-unit>
       <trans-unit id="6191074751909534346" datatype="html">
         <source>action-triggers.selected-action.label</source>
-        <target state="new">Selected action</target>
+        <target>Selected action</target>
       </trans-unit>
       <trans-unit id="5115532688749023793" datatype="html">
         <source>action-triggers.no-selected-action.label</source>
-        <target state="new">No selected action</target>
+        <target>No selected action</target>
       </trans-unit>
       <trans-unit id="4104115551404451182" datatype="html">
         <source>dialog.button.activate</source>
-        <target state="new">Aktiver</target>
+        <target>Aktiver</target>
       </trans-unit>
       <trans-unit id="6184838723314474094" datatype="html">
         <source>dialog.button.rehearse</source>
-        <target state="new">Afprøv</target>
+        <target>Afprøv</target>
       </trans-unit>
       <trans-unit id="5333590585565329092" datatype="html">
         <source>dialog.message.activation</source>
-        <target state="new">Er du sikker på at du vil aktivere denne Rundown?</target>
+        <target>Er du sikker på at du vil aktivere denne Rundown?</target>
       </trans-unit>
       <trans-unit id="3626510894964414637" datatype="html">
         <source>dialog.message.activation.warning</source>
-        <target state="new">Er du sikker på du vil aktivere denne Rundown? Det vil deaktivere Rundown</target>
+        <target>Er du sikker på du vil aktivere denne Rundown? Det vil deaktivere Rundown</target>
       </trans-unit>
       <trans-unit id="6370990329720066506" datatype="html">
         <source>dialog.message.rehearse</source>
-        <target state="new">Er du sikker på at du vil afprøve denne Rundown?</target>
+        <target>Er du sikker på at du vil afprøve denne Rundown?</target>
       </trans-unit>
       <trans-unit id="2994423491366084246" datatype="html">
         <source>dialog.message.rehearse.warning</source>
-        <target state="new">Er du sikker på at du vil afprøve denne Rundown? Det vil deaktivere Rundown</target>
+        <target>Er du sikker på at du vil afprøve denne Rundown? Det vil deaktivere Rundown</target>
       </trans-unit>
       <trans-unit id="3407985762844707521" datatype="html">
         <source>static-buttons-configuration.card-header</source>
-        <target state="new">Permanente Knapper</target>
+        <target>Permanente Knapper</target>
       </trans-unit>
       <trans-unit id="6692919644654752745" datatype="html">
         <source>edit-static-buttons-dialog.header</source>
-        <target state="new">Tilføj eller Fjern Permanente Knapper</target>
+        <target>Tilføj eller Fjern Permanente Knapper</target>
       </trans-unit>
       <trans-unit id="5375689081015240470" datatype="html">
         <source>static-buttons-configuration.edit-configuration.success</source>
-        <target state="new">Permanente knapper blev opdateret</target>
+        <target>Permanente knapper blev opdateret</target>
       </trans-unit>
       <trans-unit id="4296700921833037953" datatype="html">
         <source>edit-static-buttons.remove-static-button.tooltip</source>
-        <target state="new">edit-static-buttons.remove-static-button.tooltip</target>
+        <target>edit-static-buttons.remove-static-button.tooltip</target>
       </trans-unit>
       <trans-unit id="9099550788779670007" datatype="html">
         <source>common.save-and-create-new</source>
-        <target state="new">Gem og opret ny</target>
+        <target>Gem og opret ny</target>
       </trans-unit>
       <trans-unit id="3477258835430959446" datatype="html">
         <source>keyboard-mapping-settings-page.delete-all-keyboard-mappings.success <x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/></source>
-        <target state="new"><x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/> genveje blev slettet</target>
+        <target><x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/> genveje blev slettet</target>
       </trans-unit>
       <trans-unit id="5805882241277564116" datatype="html">
         <source>keyboard-mapping-settings-page-import-keyboard-mappings.actions-missing</source>
-        <target state="new">En eller flere importeret genveje havde en ugyldig action og blev derfor ikke importeret!</target>
+        <target>En eller flere importeret genveje havde en ugyldig action og blev derfor ikke importeret!</target>
       </trans-unit>
       <trans-unit id="8483503986037571867" datatype="html">
         <source>action-triggers.override-color.label</source>
-        <target state="new">Overskriv genvejs farven</target>
+        <target>Overskriv genvejs farven</target>
       </trans-unit>
       <trans-unit id="2313705565869821168" datatype="html">
         <source>color-picker.choose-color.placeholder</source>
-        <target state="new">Vælg en farve</target>
+        <target>Vælg en farve</target>
       </trans-unit>
       <trans-unit id="4439615397476866844" datatype="html">
         <source>action-triggers.override-color.help-text</source>
-        <target state="new">Vælg en ny farve hvis du gerne vil overskrive farven for genvejen.</target>
+        <target>Vælg en ny farve hvis du gerne vil overskrive farven for genvejen.</target>
+      </trans-unit>
+      <trans-unit id="1585014730962068045" datatype="html">
+        <source>invalid-part-tooltip.invalid-part.label</source>
+        <target>Parten er ugyldig.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.da.xlf
+++ b/src/locale/messages.da.xlf
@@ -506,6 +506,14 @@
         <source>invalid-part-tooltip.invalid-part.label</source>
         <target>Parten er ugyldig.</target>
       </trans-unit>
+      <trans-unit id="2366487849326287203" datatype="html">
+        <source>invalid-segment.invalid.label</source>
+        <target>UGYLDIG</target>
+      </trans-unit>
+      <trans-unit id="1956737595735469040" datatype="html">
+        <source>segment.unsynced.label</source>
+        <target>USYNKRONISERET</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.en-US.xlf
+++ b/src/locale/messages.en-US.xlf
@@ -506,6 +506,14 @@
         <source>invalid-part-tooltip.invalid-part.label</source>
         <target>The part is invalid.</target>
       </trans-unit>
+      <trans-unit id="2366487849326287203" datatype="html">
+        <source>invalid-segment.invalid.label</source>
+        <target>INVALID</target>
+      </trans-unit>
+      <trans-unit id="1956737595735469040" datatype="html">
+        <source>segment.unsynced.label</source>
+        <target>UNSYNCED</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.en-US.xlf
+++ b/src/locale/messages.en-US.xlf
@@ -56,451 +56,455 @@
       </trans-unit>
       <trans-unit id="7774679192134693239" datatype="html">
         <source>rundown-overview.settings.title</source>
-        <target state="new">Settings</target>
+        <target>Settings</target>
       </trans-unit>
       <trans-unit id="4380077604653787346" datatype="html">
         <source>settings.clear-cache.label</source>
-        <target state="new">Clear cache</target>
+        <target>Clear cache</target>
       </trans-unit>
       <trans-unit id="7618983089240067205" datatype="html">
         <source>action-triggers.shortcut.label</source>
-        <target state="new">Shortcut</target>
+        <target>Shortcut</target>
       </trans-unit>
       <trans-unit id="1532790028301204513" datatype="html">
         <source>global.delete.label</source>
-        <target state="new">Delete</target>
+        <target>Delete</target>
       </trans-unit>
       <trans-unit id="386627600927064568" datatype="html">
         <source>keyboard-mapping.delete-selected.confirmation</source>
-        <target state="new">Are you sure you want to delete all selected keyboard mappings?</target>
+        <target>Are you sure you want to delete all selected keyboard mappings?</target>
       </trans-unit>
       <trans-unit id="6285874749005785753" datatype="html">
         <source>global.label</source>
-        <target state="new">Label</target>
+        <target>Label</target>
       </trans-unit>
       <trans-unit id="9004520789605873710" datatype="html">
         <source>global.close.button</source>
-        <target state="new">Close</target>
+        <target>Close</target>
       </trans-unit>
       <trans-unit id="5199708374936679830" datatype="html">
         <source>global.delete-selected.label</source>
-        <target state="new">Delete selected</target>
+        <target>Delete selected</target>
       </trans-unit>
       <trans-unit id="9158000000301348817" datatype="html">
         <source>action-triggers.trigger-on.label</source>
-        <target state="new">Trigger on</target>
+        <target>Trigger on</target>
       </trans-unit>
       <trans-unit id="5943393457796095490" datatype="html">
         <source>action-triggers.physical-mapping.label</source>
-        <target state="new">Physical mapping</target>
+        <target>Physical mapping</target>
       </trans-unit>
       <trans-unit id="5384713853490936899" datatype="html">
         <source>clear-cache.title</source>
-        <target state="new">Clear cache</target>
+        <target>Clear cache</target>
       </trans-unit>
       <trans-unit id="7955116266682092985" datatype="html">
         <source>clear-cache.button.label</source>
-        <target state="new">Clear configuration cache</target>
+        <target>Clear configuration cache</target>
       </trans-unit>
       <trans-unit id="7840343495376792564" datatype="html">
         <source>global.confirmation.label</source>
-        <target state="new">Confirmation</target>
+        <target>Confirmation</target>
       </trans-unit>
       <trans-unit id="6681316063292517711" datatype="html">
         <source>clear-cache.clear.confirmation</source>
-        <target state="new">Are you sure you want to clear your cache?</target>
+        <target>Are you sure you want to clear your cache?</target>
       </trans-unit>
       <trans-unit id="1544567860044151272" datatype="html">
         <source>global.clear.label</source>
-        <target state="new">Clear</target>
+        <target>Clear</target>
       </trans-unit>
       <trans-unit id="9191550720479888548" datatype="html">
         <source>settings.keyboard-mappings.title</source>
-        <target state="new">Keyboard mappings</target>
+        <target>Keyboard mappings</target>
       </trans-unit>
       <trans-unit id="4177582797246824978" datatype="html">
         <source>action-triggers.physical-mapping-help.tooltip</source>
-        <target state="new">The physical key combination that should be shown on the virtual keyboard in the rundown view. The field should only be used if the key combination is altered by a key mapping software like AutoHotKey.</target>
+        <target>The physical key combination that should be shown on the virtual keyboard in the rundown view. The field should only be used if the key combination is altered by a key mapping software like AutoHotKey.</target>
       </trans-unit>
       <trans-unit id="9012317992372082365" datatype="html">
         <source>global.next.label</source>
-        <target state="new">NEXT</target>
+        <target>NEXT</target>
       </trans-unit>
       <trans-unit id="5184481909550121889" datatype="html">
         <source>global.auto.label</source>
-        <target state="new">AUTO</target>
+        <target>AUTO</target>
       </trans-unit>
       <trans-unit id="4384831734174772961" datatype="html">
         <source>settings.shelf.label</source>
-        <target state="new">Shelf</target>
+        <target>Shelf</target>
       </trans-unit>
       <trans-unit id="4302180445374821108" datatype="html">
         <source>settings.shelf.action-panels.title</source>
-        <target state="new">Shelf Action panels</target>
+        <target>Shelf Action panels</target>
       </trans-unit>
       <trans-unit id="2803021013738697812" datatype="html">
         <source>global.create.label</source>
-        <target state="new">Create</target>
+        <target>Create</target>
       </trans-unit>
       <trans-unit id="6050389772118678864" datatype="html">
         <source>global.export.label</source>
-        <target state="new">Export</target>
+        <target>Export</target>
       </trans-unit>
       <trans-unit id="621872648794619093" datatype="html">
         <source>piece.lifespan.within-part</source>
-        <target state="new">Within part</target>
+        <target>Within part</target>
       </trans-unit>
       <trans-unit id="1624699664203091977" datatype="html">
         <source>piece.lifespan.sticky-until-segment-change</source>
-        <target state="new">Stays until segment changes</target>
+        <target>Stays until segment changes</target>
       </trans-unit>
       <trans-unit id="8704971237918811774" datatype="html">
         <source>piece.lifespan.sticky-until-segment-end</source>
-        <target state="new">Stays until segment ends</target>
+        <target>Stays until segment ends</target>
       </trans-unit>
       <trans-unit id="1512530649495667717" datatype="html">
         <source>piece.lifespan.sticky-until-rundown-change</source>
-        <target state="new">Stays until rundown changes</target>
+        <target>Stays until rundown changes</target>
       </trans-unit>
       <trans-unit id="7630473968632852036" datatype="html">
         <source>piece.lifespan.spanning-until-rundown-end</source>
-        <target state="new">Spanning until rundown ends</target>
+        <target>Spanning until rundown ends</target>
       </trans-unit>
       <trans-unit id="558457345008559478" datatype="html">
         <source>piece.lifespan.start-spanning-segment-then-sticky-rundown</source>
-        <target state="new">Spanning segment the stays on rundown</target>
+        <target>Spanning segment the stays on rundown</target>
       </trans-unit>
       <trans-unit id="1016737278364313295" datatype="html">
         <source>piece.lifespan.unknown</source>
-        <target state="new">Unknown</target>
+        <target>Unknown</target>
       </trans-unit>
       <trans-unit id="249423270498322985" datatype="html">
         <source>action-panel.panel-name.label</source>
-        <target state="new">Panel name</target>
+        <target>Panel name</target>
       </trans-unit>
       <trans-unit id="1146669822886669522" datatype="html">
         <source>piece-tooltip-content.name.label</source>
-        <target state="new">Name</target>
+        <target>Name</target>
       </trans-unit>
       <trans-unit id="4345807184627930663" datatype="html">
         <source>piece-tooltip-content.name-of-clip.label</source>
-        <target state="new">Name of clip</target>
+        <target>Name of clip</target>
       </trans-unit>
       <trans-unit id="6258196151878366535" datatype="html">
         <source>piece-tooltip-content.name-of-pilot.label</source>
-        <target state="new">Name of pilot</target>
+        <target>Name of pilot</target>
       </trans-unit>
       <trans-unit id="247703202619960491" datatype="html">
         <source>piece-tooltip-content.template-name.label</source>
-        <target state="new">Template name</target>
+        <target>Template name</target>
       </trans-unit>
       <trans-unit id="2286645272575381009" datatype="html">
         <source>piece-tooltip-content.content-of-all-fields.label</source>
-        <target state="new">Content of all fields</target>
+        <target>Content of all fields</target>
       </trans-unit>
       <trans-unit id="1962663410998124131" datatype="html">
         <source>piece-tooltip-content.duration.label</source>
-        <target state="new">Duration</target>
+        <target>Duration</target>
       </trans-unit>
       <trans-unit id="2911851896669162406" datatype="html">
         <source>piece-tooltip-content.available-for-playout.label</source>
-        <target state="new">Available for playout</target>
+        <target>Available for playout</target>
       </trans-unit>
       <trans-unit id="1044477716904098041" datatype="html">
         <source>piece-tooltip-content.time-code-in-part.label</source>
-        <target state="new">Time code in part</target>
+        <target>Time code in part</target>
       </trans-unit>
       <trans-unit id="3495993720885162413" datatype="html">
         <source>action-panel.rank.label</source>
-        <target state="new">Rank</target>
+        <target>Rank</target>
       </trans-unit>
       <trans-unit id="3000985957863398667" datatype="html">
         <source>piece-tooltip-content.out-type.label</source>
-        <target state="new">Out type</target>
+        <target>Out type</target>
       </trans-unit>
       <trans-unit id="1842982718967386055" datatype="html">
         <source>global.audio.label</source>
-        <target state="new">Audio</target>
+        <target>Audio</target>
       </trans-unit>
       <trans-unit id="8147260465029418817" datatype="html">
         <source>piece-tooltip-content.unknown.data</source>
-        <target state="new">Unknown</target>
+        <target>Unknown</target>
       </trans-unit>
       <trans-unit id="389262478828731921" datatype="html">
         <source>global.remote.label</source>
-        <target state="new">Remote</target>
+        <target>Remote</target>
       </trans-unit>
       <trans-unit id="4174829375203668461" datatype="html">
         <source>piece-tooltip-content.no-specific-time-code.data</source>
-        <target state="new">(No specific time code)</target>
+        <target>(No specific time code)</target>
       </trans-unit>
       <trans-unit id="6046979654633268329" datatype="html">
         <source>global.camera.label</source>
-        <target state="new">Camera</target>
+        <target>Camera</target>
       </trans-unit>
       <trans-unit id="717945474169849731" datatype="html">
         <source>global.yes</source>
-        <target state="new">Yes</target>
+        <target>Yes</target>
       </trans-unit>
       <trans-unit id="2951845926043442554" datatype="html">
         <source>global.graphics.label</source>
-        <target state="new">Graphics</target>
+        <target>Graphics</target>
       </trans-unit>
       <trans-unit id="8248235614614318568" datatype="html">
         <source>global.no</source>
-        <target state="new">No</target>
+        <target>No</target>
       </trans-unit>
       <trans-unit id="8361312030303141039" datatype="html">
         <source>global.replay.label</source>
-        <target state="new">Replay</target>
+        <target>Replay</target>
       </trans-unit>
       <trans-unit id="1887044897982242749" datatype="html">
         <source>global.robot.label</source>
-        <target state="new">Robot</target>
+        <target>Robot</target>
       </trans-unit>
       <trans-unit id="7053378516611820006" datatype="html">
         <source>global.split-screen.label</source>
-        <target state="new">Split screen</target>
+        <target>Split screen</target>
       </trans-unit>
       <trans-unit id="8633433908703192113" datatype="html">
         <source>global.transition.label</source>
-        <target state="new">Transition</target>
+        <target>Transition</target>
       </trans-unit>
       <trans-unit id="8164633860480723989" datatype="html">
         <source>global.unknown.label</source>
-        <target state="new">Unknown</target>
+        <target>Unknown</target>
       </trans-unit>
       <trans-unit id="3522238577113202288" datatype="html">
         <source>global.video-clip.label</source>
-        <target state="new">Video clip</target>
+        <target>Video clip</target>
       </trans-unit>
       <trans-unit id="5944821486251382171" datatype="html">
         <source>global.filters.label</source>
-        <target state="new">Filters</target>
+        <target>Filters</target>
       </trans-unit>
       <trans-unit id="125592769491380843" datatype="html">
         <source>action-panel.delete.confirmation</source>
-        <target state="new">Are you sure you want to delete this action panel?</target>
+        <target>Are you sure you want to delete this action panel?</target>
       </trans-unit>
       <trans-unit id="4121868262213030663" datatype="html">
         <source>global.import.button</source>
-        <target state="new">Import</target>
+        <target>Import</target>
       </trans-unit>
       <trans-unit id="1489043303962671570" datatype="html">
         <source>keyboard-mapping.delete.confirmation</source>
-        <target state="new">Are you sure you want to delete this Keyboard Mapping?</target>
+        <target>Are you sure you want to delete this Keyboard Mapping?</target>
       </trans-unit>
       <trans-unit id="1426591653041922259" datatype="html">
         <source>edit-keyboard-mapping.edit</source>
-        <target state="new">Edit Keyboard Mapping</target>
+        <target>Edit Keyboard Mapping</target>
       </trans-unit>
       <trans-unit id="1469306793833284818" datatype="html">
         <source>edit-keyboard-mapping.create</source>
-        <target state="new">Create Keyboard Mapping</target>
+        <target>Create Keyboard Mapping</target>
       </trans-unit>
       <trans-unit id="3570927086139625658" datatype="html">
         <source>edit-shelf-action-panel-configuration.edit</source>
-        <target state="new">Edit Action Panel configuration</target>
+        <target>Edit Action Panel configuration</target>
       </trans-unit>
       <trans-unit id="7388536117729067" datatype="html">
         <source>edit-shelf-action-panel-configuration.create</source>
-        <target state="new">Create Action Panel configuration</target>
+        <target>Create Action Panel configuration</target>
       </trans-unit>
       <trans-unit id="8113227000238039449" datatype="html">
         <source>empty.table</source>
-        <target state="new">No entries found</target>
+        <target>No entries found</target>
       </trans-unit>
       <trans-unit id="377801051239310294" datatype="html">
         <source>rundown-overview-component.planned-start</source>
-        <target state="new">Planned start</target>
+        <target>Planned start</target>
       </trans-unit>
       <trans-unit id="1759269174172455303" datatype="html">
         <source>rundown-overview-component.duration</source>
-        <target state="new">Duration</target>
+        <target>Duration</target>
       </trans-unit>
       <trans-unit id="5719401361944025947" datatype="html">
         <source>rundown-overview-component.planned-end</source>
-        <target state="new">Planned end</target>
+        <target>Planned end</target>
       </trans-unit>
       <trans-unit id="265486137243693578" datatype="html">
         <source>common-search</source>
-        <target state="new">Search</target>
+        <target>Search</target>
       </trans-unit>
       <trans-unit id="7507229359295852513" datatype="html">
         <source>keyboard-mapping-settings-page.edit-action-panel</source>
-        <target state="new">Edit Action panel</target>
+        <target>Edit Action panel</target>
       </trans-unit>
       <trans-unit id="4970317883878168308" datatype="html">
         <source>keyboard-mapping-settings-page.copy-action-panel</source>
-        <target state="new">Copy Action panel</target>
+        <target>Copy Action panel</target>
       </trans-unit>
       <trans-unit id="6885589310720431669" datatype="html">
         <source>keyboard-mapping-settings-page.delete-action-panel</source>
-        <target state="new">Delete Action panel</target>
+        <target>Delete Action panel</target>
       </trans-unit>
       <trans-unit id="8250191741920581081" datatype="html">
         <source>action-selector.select-action</source>
-        <target state="new">Select an Action</target>
+        <target>Select an Action</target>
       </trans-unit>
       <trans-unit id="1039010698457393444" datatype="html">
         <source>action-selector.search-action</source>
-        <target state="new">Search for an Action</target>
+        <target>Search for an Action</target>
       </trans-unit>
       <trans-unit id="985670024801490264" datatype="html">
         <source>keyboard-mapping-settings-page.delete-keyboard-mapping.success</source>
-        <target state="new">Successfully deleted Keyboard Mapping</target>
+        <target>Successfully deleted Keyboard Mapping</target>
       </trans-unit>
       <trans-unit id="3545744709165250098" datatype="html">
         <source>keyboard-mapping-settings-page.duplicate-keyboard-mapping.success</source>
-        <target state="new">Successfully duplicated Keyboard Mapping</target>
+        <target>Successfully duplicated Keyboard Mapping</target>
       </trans-unit>
       <trans-unit id="7491316453773946580" datatype="html">
         <source>keyboard-mapping-settings-page.create-keyboard-mapping.success</source>
-        <target state="new">Successfully created Keyboard Mapping</target>
+        <target>Successfully created Keyboard Mapping</target>
       </trans-unit>
       <trans-unit id="4004671805035160284" datatype="html">
         <source>keyboard-mapping-settings-page.update-keyboard-mapping.success</source>
-        <target state="new">Successfully updated Keyboard Mapping</target>
+        <target>Successfully updated Keyboard Mapping</target>
       </trans-unit>
       <trans-unit id="6679898506590591687" datatype="html">
         <source>keyboard-mapping-settings-page.import-keyboard-mappings.success</source>
-        <target state="new">Successfully imported keyboard mappings</target>
+        <target>Successfully imported keyboard mappings</target>
       </trans-unit>
       <trans-unit id="2265780212602106942" datatype="html">
         <source>keyboard-mapping-settings-page.delete-all-keyboard-mappings.fail</source>
-        <target state="new">Something went wrong deleting keyboard mappings</target>
+        <target>Something went wrong deleting keyboard mappings</target>
       </trans-unit>
       <trans-unit id="976917377731196434" datatype="html">
         <source>shelf-action-panel-settings-page.create-action-panel.success <x id="PH" equiv-text="createdActionPanel.name"/></source>
-        <target state="new">Successfully created Action Panel: <x id="PH" equiv-text="result.name"/></target>
+        <target>Successfully created Action Panel: <x id="PH" equiv-text="result.name"/></target>
       </trans-unit>
       <trans-unit id="4084730079945397668" datatype="html">
         <source>shelf-action-panel-settings.page.update-action-panel.success <x id="PH" equiv-text="updatedActionPanel.name"/></source>
-        <target state="new">Successfully updated Action Panel: <x id="PH" equiv-text="result.name"/></target>
+        <target>Successfully updated Action Panel: <x id="PH" equiv-text="result.name"/></target>
       </trans-unit>
       <trans-unit id="2441219618501183432" datatype="html">
         <source>shelf-action-panel-settings-page.selected-action-panels.deleted</source>
-        <target state="new">Selected Action Panels were deleted</target>
+        <target>Selected Action Panels were deleted</target>
       </trans-unit>
       <trans-unit id="5114970090218136617" datatype="html">
         <source>common.save</source>
-        <target state="new">Save</target>
+        <target>Save</target>
       </trans-unit>
       <trans-unit id="3623062952070884482" datatype="html">
         <source>piece-tooltip.source-unavailable.label</source>
-        <target state="new">Source is unavailable!</target>
+        <target>Source is unavailable!</target>
       </trans-unit>
       <trans-unit id="8873287033928471003" datatype="html">
         <source>keyboard-mapping-settings-page.import-keyboard-mappings.failure</source>
-        <target state="new">Something went wrong importing the keyboard shortcuts</target>
+        <target>Something went wrong importing the keyboard shortcuts</target>
       </trans-unit>
       <trans-unit id="8291594485469554782" datatype="html">
         <source>notification-icon.toggle-panel.tooltip</source>
-        <target state="new">Click to toggle notification panel</target>
+        <target>Click to toggle notification panel</target>
       </trans-unit>
       <trans-unit id="3299373246271290710" datatype="html">
         <source>action-triggers.action.label</source>
-        <target state="new">Action</target>
+        <target>Action</target>
       </trans-unit>
       <trans-unit id="719177318571875364" datatype="html">
         <source>common.form-required-field.button-tooltip</source>
-        <target state="new">Please fill out the required field(s).</target>
+        <target>Please fill out the required field(s).</target>
       </trans-unit>
       <trans-unit id="5742386463554387927" datatype="html">
         <source>action-triggers.shortcut.error</source>
-        <target state="new">A shortcut is required.</target>
+        <target>A shortcut is required.</target>
       </trans-unit>
       <trans-unit id="6359779760013296434" datatype="html">
         <source>action-triggers.trigger-on.error</source>
-        <target state="new">Please select how the shortcut should trigger.</target>
+        <target>Please select how the shortcut should trigger.</target>
       </trans-unit>
       <trans-unit id="6127544094154745108" datatype="html">
         <source><x id="PH" equiv-text="this.selectedAction?.argument?.name"/> action-triggers.action-arguments.error</source>
-        <target state="new"><x id="PH" equiv-text="this.selectedAction?.argument?.name!"/> is required.</target>
+        <target><x id="PH" equiv-text="this.selectedAction?.argument?.name!"/> is required.</target>
       </trans-unit>
       <trans-unit id="979335411678822239" datatype="html">
         <source>action-panel.name.error</source>
-        <target state="new">Please fill out a name.</target>
+        <target>Please fill out a name.</target>
       </trans-unit>
       <trans-unit id="5202318571157878044" datatype="html">
         <source>action-panel.action-filter.error</source>
-        <target state="new">Select at least one filter.</target>
+        <target>Select at least one filter.</target>
       </trans-unit>
       <trans-unit id="770599904666863258" datatype="html">
         <source>action-panel.rank.error</source>
-        <target state="new">The panel must have a rank provided.</target>
+        <target>The panel must have a rank provided.</target>
       </trans-unit>
       <trans-unit id="6191074751909534346" datatype="html">
         <source>action-triggers.selected-action.label</source>
-        <target state="new">Selected action</target>
+        <target>Selected action</target>
       </trans-unit>
       <trans-unit id="5115532688749023793" datatype="html">
         <source>action-triggers.no-selected-action.label</source>
-        <target state="new">No selected action</target>
+        <target>No selected action</target>
       </trans-unit>
       <trans-unit id="4104115551404451182" datatype="html">
         <source>dialog.button.activate</source>
-        <target state="new">Activate</target>
+        <target>Activate</target>
       </trans-unit>
       <trans-unit id="6184838723314474094" datatype="html">
         <source>dialog.button.rehearse</source>
-        <target state="new">Rehearse</target>
+        <target>Rehearse</target>
       </trans-unit>
       <trans-unit id="5333590585565329092" datatype="html">
         <source>dialog.message.activation</source>
-        <target state="new">Are you sure you want to activate the Rundown?</target>
+        <target>Are you sure you want to activate the Rundown?</target>
       </trans-unit>
       <trans-unit id="3626510894964414637" datatype="html">
         <source>dialog.message.activation.warning</source>
-        <target state="new">Are you sure you want to activate the Rundown? This will deactivate the Rundown</target>
+        <target>Are you sure you want to activate the Rundown? This will deactivate the Rundown</target>
       </trans-unit>
       <trans-unit id="6370990329720066506" datatype="html">
         <source>dialog.message.rehearse</source>
-        <target state="new">Are you sure you want to rehearse the Rundown?</target>
+        <target>Are you sure you want to rehearse the Rundown?</target>
       </trans-unit>
       <trans-unit id="2994423491366084246" datatype="html">
         <source>dialog.message.rehearse.warning</source>
-        <target state="new">Are you sure you want to rehearse the Rundown? This will deactivate the Rundown</target>
+        <target>Are you sure you want to rehearse the Rundown? This will deactivate the Rundown</target>
       </trans-unit>
       <trans-unit id="3407985762844707521" datatype="html">
         <source>static-buttons-configuration.card-header</source>
-        <target state="new">Static Buttons</target>
+        <target>Static Buttons</target>
       </trans-unit>
       <trans-unit id="6692919644654752745" datatype="html">
         <source>edit-static-buttons-dialog.header</source>
-        <target state="new">Add or Remove Static Buttons</target>
+        <target>Add or Remove Static Buttons</target>
       </trans-unit>
       <trans-unit id="5375689081015240470" datatype="html">
         <source>static-buttons-configuration.edit-configuration.success</source>
-        <target state="new">Changed static buttons successfully!</target>
+        <target>Changed static buttons successfully!</target>
       </trans-unit>
       <trans-unit id="4296700921833037953" datatype="html">
         <source>edit-static-buttons.remove-static-button.tooltip</source>
-        <target state="new">Remove static button</target>
+        <target>Remove static button</target>
       </trans-unit>
       <trans-unit id="9099550788779670007" datatype="html">
         <source>common.save-and-create-new</source>
-        <target state="new">Save and create new</target>
+        <target>Save and create new</target>
       </trans-unit>
       <trans-unit id="3477258835430959446" datatype="html">
         <source>keyboard-mapping-settings-page.delete-all-keyboard-mappings.success <x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/></source>
-        <target state="new">The <x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/> selected keyboard mappings have been deleted.</target>
+        <target>The <x id="PH" equiv-text="actionTriggerIdsToBeDeleted.length"/> selected keyboard mappings have been deleted.</target>
       </trans-unit>
       <trans-unit id="5805882241277564116" datatype="html">
         <source>keyboard-mapping-settings-page-import-keyboard-mappings.actions-missing</source>
-        <target state="new">One or more keyboard mappings contained invalid actions and were not imported!</target>
+        <target>One or more keyboard mappings contained invalid actions and were not imported!</target>
       </trans-unit>
       <trans-unit id="8483503986037571867" datatype="html">
         <source>action-triggers.override-color.label</source>
-        <target state="new">Override key color</target>
+        <target>Override key color</target>
       </trans-unit>
       <trans-unit id="2313705565869821168" datatype="html">
         <source>color-picker.choose-color.placeholder</source>
-        <target state="new">Choose a color</target>
+        <target>Choose a color</target>
       </trans-unit>
       <trans-unit id="4439615397476866844" datatype="html">
         <source>action-triggers.override-color.help-text</source>
-        <target state="new">Choose a color if you want to override the key color of the keyboard mapping.</target>
+        <target>Choose a color if you want to override the key color of the keyboard mapping.</target>
+      </trans-unit>
+      <trans-unit id="1585014730962068045" datatype="html">
+        <source>invalid-part-tooltip.invalid-part.label</source>
+        <target>The part is invalid.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -377,6 +377,9 @@
       <trans-unit id="8483503986037571867" datatype="html">
         <source>action-triggers.override-color.label</source>
       </trans-unit>
+      <trans-unit id="1585014730962068045" datatype="html">
+        <source>invalid-part-tooltip.invalid-part.label</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -380,6 +380,12 @@
       <trans-unit id="1585014730962068045" datatype="html">
         <source>invalid-part-tooltip.invalid-part.label</source>
       </trans-unit>
+      <trans-unit id="2366487849326287203" datatype="html">
+        <source>invalid-segment.invalid.label</source>
+      </trans-unit>
+      <trans-unit id="1956737595735469040" datatype="html">
+        <source>segment.unsynced.label</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/scss/_sofie-color-vars.scss
+++ b/src/scss/_sofie-color-vars.scss
@@ -53,7 +53,6 @@ body {
   --rundown-draggable-shelf-color: #555555;
   --rundown-segment-header-background-color: #4b4b4b;
   --rundown-draggable-shelf-hover-color: #888888;
-  --rundown-unsynced-segment-color: #ffff00ba;
   --rundown-timeline-marker-color: #5f6164;
 
   --gradient-black-rgba-with-02-opacity-color: rgba(0, 0, 0, 0.2);
@@ -62,7 +61,7 @@ body {
   --gradient-black-rgba-with-08-opacity-color: rgba(0, 0, 0, 0.8);
   --gradient-green-rgba-with-04-opacity-color: rgba(0, 222, 99, 0.4);
 
-  --unsynced-part-linear-gradient: repeating-linear-gradient(120deg, #00000000, #00000000 8px, #ffff0055 8px, #ffff0055 16px);
+  --unsynced-part-linear-gradient: repeating-linear-gradient(120deg, var(--transparent-color), var(--transparent-color) 8px, var(--attention-color) 8px, var(--attention-color) 16px);
   --action-panel-scrollable-before-linear-gradient: linear-gradient(90deg, #222222ff 0%, #222222ff 10%, #22222200 100%);
   --action-panel-scrollable-after-linear-gradient: linear-gradient(-90deg, #222222ff 0%, #222222ff 10%, #22222200 100%);
 


### PR DESCRIPTION
Depends on: https://github.com/tv2/sofie-server/pull/168.

The PR adds visual indication of invalid parts with an overlayed attention-colored grid, along with tooltips describing the reason for the invalidity.

<img width="1360" alt="Skærmbillede 2024-06-13 kl  09 38 06" src="https://github.com/tv2/sofie-web-client/assets/11258272/e4112192-834d-4cf4-a966-05040e60c76f">

The PR also introduces the `AttentionBannerComponent`, which removes the redundant styling and setup we have for showing a banner with warning icon, a label and a description.
By doing this, the color of the _UNSYNCED_ banner on the segment header is changed to use the attention color, like  the invalid segment banner.

The container showing overlays for parts have been changed to use the full height, such that the visual impact for part overlays is greater.

<img width="1337" alt="Skærmbillede 2024-06-13 kl  09 41 30" src="https://github.com/tv2/sofie-web-client/assets/11258272/c2368c34-307b-41c6-bb30-3f318f81c72e">
