### PR TITLE
SOF-2025 - Bug: Span piece until segment end

### DIFF
--- a/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.html
+++ b/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.html
@@ -5,19 +5,12 @@
   [class.media-unavailable]="isMediaUnavailable()"
   sofieTooltip
   [sofieTooltipTemplate]="pieceTooltip"
-  (tooltipMetadataChange)="updatePositionInVideo($event)"
->
+  (tooltipMetadataChange)="updatePositionInVideo($event)">
   <div class="label" [style.margin-left.px]="labelOffsetInPixels">
-    <span #labelTextElement>{{ piece.name }}</span>
+    <span *ngIf="piece.isSpanned !== true" #labelTextElement>{{ piece.name }}</span>
   </div>
 </div>
 
 <ng-template #pieceTooltip>
-    <sofie-piece-tooltip
-            [piece]="piece"
-            [durationInMs]="partDuration"
-            [media]="media"
-            [positionInVideoInMs]="positionInVideoInMs"
-    >
-    </sofie-piece-tooltip>
+  <sofie-piece-tooltip [piece]="piece" [durationInMs]="partDuration" [media]="media" [positionInVideoInMs]="positionInVideoInMs"> </sofie-piece-tooltip>
 </ng-template>

--- a/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.spec.ts
+++ b/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.spec.ts
@@ -1,9 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { OffsetablePieceComponent } from './offsetable-piece.component'
-import { instance, mock } from '@typestrong/ts-mockito'
-import { MediaStateService } from '../../../shared/services/media-state.service'
 import { ChangeDetectorRef } from '@angular/core'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { instance, mock } from '@typestrong/ts-mockito'
 import { TestEntityFactory } from 'src/app/test/factories/test-entity.factory'
+import { MediaStateService } from '../../../shared/services/media-state.service'
+import { OffsetablePieceComponent } from './offsetable-piece.component'
 
 describe(OffsetablePieceComponent.name, () => {
   let component: OffsetablePieceComponent
@@ -24,9 +24,27 @@ describe(OffsetablePieceComponent.name, () => {
     component = fixture.componentInstance
   })
 
-  it('should create', () => {
-    const mockedPiece = TestEntityFactory.createPiece()
+  it('should NOT render text inside label div when isSpanning is true', () => {
+    const mockedPiece = TestEntityFactory.createAugmentedPiece({ metadata: { type: 'testing' } })
     component.piece = mockedPiece
-    expect(component).toBeTruthy()
+    fixture.detectChanges()
+
+    const isSpanning = fixture.componentInstance.piece.isSpanned
+    const label = fixture.nativeElement.querySelector('div.label span')
+
+    expect(label).toBeNull()
+    expect(isSpanning).toBeTruthy()
+  })
+
+  it('should render text inside label div when isSpanning is undefined', () => {
+    const mockedPiece = TestEntityFactory.createPiece({ metadata: { type: 'testing' } })
+    component.piece = mockedPiece
+    fixture.detectChanges()
+
+    const isSpanning = fixture.componentInstance.piece.isSpanned
+    const label = fixture.nativeElement.querySelector('div.label span')
+
+    expect(label).toBeTruthy()
+    expect(isSpanning).toBeFalsy()
   })
 })

--- a/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.ts
+++ b/src/app/rundown-view/components/offsetable-piece/offsetable-piece.component.ts
@@ -1,13 +1,16 @@
-import { Tv2Piece } from 'src/app/core/models/tv2-piece'
 import { Component, ElementRef, HostBinding, Input, OnChanges, OnDestroy, SimpleChange, SimpleChanges, ViewChild } from '@angular/core'
-import { Tv2AudioMode } from '../../../core/enums/tv2-audio-mode'
-import { MediaStateService } from '../../../shared/services/media-state.service'
-import { Media } from '../../../shared/services/media'
 import { Subscription } from 'rxjs'
-import { Piece } from 'src/app/core/models/piece'
+import { Tv2AudioMode } from '../../../core/enums/tv2-audio-mode'
+import { Piece } from '../../../core/models/piece'
+import { Tv2Piece } from '../../../core/models/tv2-piece'
 import { TooltipMetadata } from '../../../shared/directives/tooltip.directive'
+import { Media } from '../../../shared/services/media'
+import { MediaStateService } from '../../../shared/services/media-state.service'
 
 const LABEL_TEXT_INSET_IN_PIXELS: number = 14
+type AugmentedPiece = Piece & {
+  isSpanned?: boolean
+}
 
 @Component({
   selector: 'sofie-offsetable-piece',
@@ -16,7 +19,7 @@ const LABEL_TEXT_INSET_IN_PIXELS: number = 14
 })
 export class OffsetablePieceComponent implements OnChanges, OnDestroy {
   @Input()
-  public piece: Piece
+  public piece: AugmentedPiece
 
   @Input()
   public pixelsPerSecond: number

--- a/src/app/test/factories/test-entity.factory.ts
+++ b/src/app/test/factories/test-entity.factory.ts
@@ -1,20 +1,24 @@
-import { Part } from '../../core/models/part'
-import { Segment } from '../../core/models/segment'
-import { Rundown } from '../../core/models/rundown'
-import { Piece } from '../../core/models/piece'
-import { RundownTimingType } from '../../core/enums/rundown-timing-type'
-import { ActionTrigger } from 'src/app/shared/models/action-trigger'
-import { Tv2ActionContentType, Tv2PartAction, Tv2VideoClipAction } from 'src/app/shared/models/tv2-action'
-import { PartActionType } from 'src/app/shared/models/action-type'
-import { KeyEventType } from 'src/app/keyboard/value-objects/key-event-type'
-import { KeyboardTriggerData } from 'src/app/shared/models/keyboard-trigger-data'
-import { StudioConfiguration } from '../../shared/models/studio-configuration'
-import { Media } from '../../shared/services/media'
 import { PieceLifespan } from 'src/app/core/models/piece-lifespan'
+import { KeyEventType } from 'src/app/keyboard/value-objects/key-event-type'
+import { ActionTrigger } from 'src/app/shared/models/action-trigger'
+import { PartActionType } from 'src/app/shared/models/action-type'
+import { KeyboardTriggerData } from 'src/app/shared/models/keyboard-trigger-data'
+import { Tv2ActionContentType, Tv2PartAction, Tv2VideoClipAction } from 'src/app/shared/models/tv2-action'
+import { RundownMode } from '../../core/enums/rundown-mode'
+import { RundownTimingType } from '../../core/enums/rundown-timing-type'
+import { Part } from '../../core/models/part'
+import { Piece } from '../../core/models/piece'
+import { Rundown } from '../../core/models/rundown'
 import { AutoNextStartedEvent, PartSetAsNextEvent, RundownResetEvent } from '../../core/models/rundown-event'
 import { RundownEventType } from '../../core/models/rundown-event-type'
+import { Segment } from '../../core/models/segment'
 import { Tv2SegmentMetadata } from '../../core/models/tv2-segment-metadata'
-import { RundownMode } from '../../core/enums/rundown-mode'
+import { StudioConfiguration } from '../../shared/models/studio-configuration'
+import { Media } from '../../shared/services/media'
+
+type AugmentedPiece = Piece & {
+  isSpanned?: boolean
+}
 
 export class TestEntityFactory {
   public static createRundown(rundown: Partial<Rundown> = {}): Rundown {
@@ -77,6 +81,9 @@ export class TestEntityFactory {
       lifespan: PieceLifespan.WITHIN_PART,
       ...piece,
     }
+  }
+  public static createAugmentedPiece(piece: Partial<Piece> = {}): AugmentedPiece {
+    return { ...TestEntityFactory.createPiece(piece), isSpanned: true }
   }
 
   public static createActionTrigger(actionTrigger: Partial<ActionTrigger<KeyboardTriggerData>> = {}): ActionTrigger<KeyboardTriggerData> {


### PR DESCRIPTION
Redid the branch so it could be based off of staging instead, since this is where it will be merged to

This bugfix augments a piece in a segment before it is sent down the component tree, thus adding a "isSpanned" boolean to the object.

As it is visible in the screenshot, if a segment has more than 1 "span until segment end" piece, it will stop once it reaches the next one in the segment, and allow the next piece to be the one that is spanned.

One of the important things to notice is that the label in the piece is not shown when it is spanned.

![image](https://github.com/tv2/sofie-web-client/assets/22421190/9a9e7b1d-bff5-4913-a4db-f3d68540b786)

