### PR TITLE
fix: Side dialog background became transparent after version change

### DIFF
--- a/src/scss/_sofie-dialog.scss
+++ b/src/scss/_sofie-dialog.scss
@@ -1,4 +1,6 @@
 .sidebar-dialog {
+  background-color: var(--white-color);
+
   .mat-dialog-container {
     padding: 0 !important;
     border-radius: 0 !important;


### PR DESCRIPTION
After the angular update, our, now legacy, component used for the sidebar dialog became transparent. I added a background color to fix this for now, but we need to change our components to no longer contain legacy Angular Material components in the future. 